### PR TITLE
[Fix] 위치 권한 미확정 상태에서 위치 추적이 시작되던 문제 수정

### DIFF
--- a/DoRunDoRun/Sources/Data/RepositoryImpl/UserLocation/UserLocationRepositoryImpl.swift
+++ b/DoRunDoRun/Sources/Data/RepositoryImpl/UserLocation/UserLocationRepositoryImpl.swift
@@ -42,4 +42,12 @@ final actor UserLocationRepositoryImpl: UserLocationRepository {
     func hasLocationPermission() async -> Bool {
         locationService.hasLocationPermission()
     }
+
+    func getAuthorizationStatus() async -> LocationAuthorizationStatus {
+        locationService.getAuthorizationStatus()
+    }
+
+    func requestLocationPermission() async -> Bool {
+        await locationService.requestLocationPermission()
+    }
 }

--- a/DoRunDoRun/Sources/Data/RepositoryMock/UserLocation/UserLocationRepositoryMock.swift
+++ b/DoRunDoRun/Sources/Data/RepositoryMock/UserLocation/UserLocationRepositoryMock.swift
@@ -38,4 +38,14 @@ final actor UserLocationRepositoryMock: UserLocationRepository {
         // Mock: 항상 권한 있음
         return true
     }
+
+    func getAuthorizationStatus() async -> LocationAuthorizationStatus {
+        // Mock: 항상 허용됨
+        return .authorized
+    }
+
+    func requestLocationPermission() async -> Bool {
+        // Mock: 항상 권한 허용
+        return true
+    }
 }

--- a/DoRunDoRun/Sources/Domain/Repository/UserLocation/UserLocationRepository.swift
+++ b/DoRunDoRun/Sources/Domain/Repository/UserLocation/UserLocationRepository.swift
@@ -12,4 +12,8 @@ protocol UserLocationRepository {
     func stopTracking() async
     /// 현재 위치 권한 상태 확인
     func hasLocationPermission() async -> Bool
+    /// 현재 위치 권한 상태 반환 (notDetermined 포함)
+    func getAuthorizationStatus() async -> LocationAuthorizationStatus
+    /// 위치 권한 요청 후 사용자 응답 대기
+    func requestLocationPermission() async -> Bool
 }

--- a/DoRunDoRun/Sources/Domain/UseCase/UserLocation/UserLocationUseCase.swift
+++ b/DoRunDoRun/Sources/Domain/UseCase/UserLocation/UserLocationUseCase.swift
@@ -12,6 +12,10 @@ protocol UserLocationUseCaseProtocol {
     func stopTracking() async
     /// 현재 위치 권한 상태 확인
     func hasLocationPermission() async -> Bool
+    /// 현재 위치 권한 상태 반환 (notDetermined 포함)
+    func getAuthorizationStatus() async -> LocationAuthorizationStatus
+    /// 위치 권한 요청 후 사용자 응답 대기
+    func requestLocationPermission() async -> Bool
 }
 
 final class UserLocationUseCase: UserLocationUseCaseProtocol {
@@ -31,5 +35,13 @@ final class UserLocationUseCase: UserLocationUseCaseProtocol {
 
     func hasLocationPermission() async -> Bool {
         return await repository.hasLocationPermission()
+    }
+
+    func getAuthorizationStatus() async -> LocationAuthorizationStatus {
+        return await repository.getAuthorizationStatus()
+    }
+
+    func requestLocationPermission() async -> Bool {
+        return await repository.requestLocationPermission()
     }
 }


### PR DESCRIPTION
# 문제 원인
onAppear에서 위치 추적을 시작할 때, .notDetermined 상태에서
requestWhenInUseAuthorization()을 호출하지만 사용자의 응답을 기다리지 않고
바로 위치 추적 스트림을 시작했습니다. 이로 인해 권한이 아직 확정되지 않은
상태에서 에러가 발생하면 설정 팝업이 iOS 시스템 팝업보다 먼저 뜨게 되었습니다.

# 수정 내용
### LocationService.swift - 새로운 enum과 메서드 추가:
  - LocationAuthorizationStatus enum: notDetermined, authorized, denied 상태 구분
  - getAuthorizationStatus(): 현재 권한 상태 반환
  - requestLocationPermission(): 권한 요청 후 사용자 응답을 비동기로 대기

### RunningReadyFeature.swift - 권한 흐름 개선:
  - onAppear: 먼저 getAuthorizationStatus()로 상태 확인 → .notDetermined면
  requestLocationPermission()으로 사용자 응답 대기 → 허용되면 위치 추적 시작, 거부되면 설정 팝업 표시
  - gpsButtonTapped: 동일한 패턴 적용
  - checkLocationPermissionOnAppActive: .notDetermined 상태는 별도 처리 안 함
  (이미 onAppear에서 처리됨)

# 동작 흐름 (수정 후)
  1. 앱 처음 설치 → onAppear 실행
  2. 권한 상태 .notDetermined 확인
  3. requestLocationPermission() 호출 → iOS 시스템 권한 팝업 표시
  4. 사용자가 "허용" 또는 "허용 안 함" 선택할 때까지 대기
  5. 허용: 위치 추적 시작 / 거부: 설정 이동 팝업 표시