### PR TITLE
[Fix] 러닝 결과 화면 지도 렌더링 및 줌 레벨 개선

### DIFF
--- a/DoRunDoRun/Sources/Presentation/Running/RunningDetail/Views/RouteFitMapView.swift
+++ b/DoRunDoRun/Sources/Presentation/Running/RunningDetail/Views/RouteFitMapView.swift
@@ -128,6 +128,9 @@ struct RouteFitMapView: UIViewRepresentable {
         )
     }
 
+    /// 짧은 경로에서 지도가 과도하게 확대되지 않도록 제한하는 최대 줌 레벨
+    private static let maxZoomLevel: Double = 17
+
     private func fitCamera(to bounds: NMGLatLngBounds, in mapView: NMFMapView) {
         let inset = UIEdgeInsets(
             top: cameraEdgeInsetAdjustment,
@@ -138,6 +141,13 @@ struct RouteFitMapView: UIViewRepresentable {
         let update = NMFCameraUpdate(fit: bounds, paddingInsets: inset)
         update.animation = .none
         mapView.moveCamera(update)
+
+        // 짧은 경로일 때 과도한 확대 방지
+        if mapView.zoomLevel > Self.maxZoomLevel {
+            let zoomUpdate = NMFCameraUpdate(zoomTo: Self.maxZoomLevel)
+            zoomUpdate.animation = .none
+            mapView.moveCamera(zoomUpdate)
+        }
     }
     
     // MARK: - Make Snapshot Data

--- a/DoRunDoRun/Sources/Presentation/Running/RunningDetail/Views/RunningDetailView.swift
+++ b/DoRunDoRun/Sources/Presentation/Running/RunningDetail/Views/RunningDetailView.swift
@@ -17,73 +17,71 @@ struct RunningDetailView: View {
         WithPerceptionTracking {
             ZStack {
                 // MARK: - Main Content
-                VStack(spacing: .zero) {
-                    HStack(spacing: 4) {
-                        Image(.distance, fill: .fill, size: .small)
-                            .renderingMode(.template)
-                            .foregroundStyle(Color.blue600)
-                        TypographyText(text: store.detail.startedAtText, style: .b2_500, color: .gray700)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 16)
-                    
-                    HStack {
-                        VStack(alignment: .leading, spacing: 12) {
-                            VStack(alignment: .leading, spacing: .zero) {
-                                TypographyText(text: "달린 거리", style: .c1_400, color: .gray500)
-                                TypographyText(text: store.detail.totalDistanceText, style: .h1_700, color: .gray900)
-                            }
-                            VStack(alignment: .leading, spacing: .zero) {
-                                TypographyText(text: "평균 페이스", style: .c1_400, color: .gray500)
-                                TypographyText(text: store.detail.avgPaceText, style: .t1_700, color: .gray900)
-                            }
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack(spacing: 4) {
+                            Image(.distance, fill: .fill, size: .small)
+                                .renderingMode(.template)
+                                .foregroundStyle(Color.blue600)
+                            TypographyText(text: store.detail.startedAtText, style: .b2_500, color: .gray700)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        
-                        VStack(alignment: .leading, spacing: 12) {
-                            VStack(alignment: .leading, spacing: .zero) {
-                                TypographyText(text: "달린 시간", style: .c1_400, color: .gray500)
-                                TypographyText(text: store.detail.durationText, style: .h1_700, color: .gray900)
+                        .padding(.vertical, 16)
+
+                        HStack {
+                            VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: .zero) {
+                                    TypographyText(text: "달린 거리", style: .c1_400, color: .gray500)
+                                    TypographyText(text: store.detail.totalDistanceText, style: .h1_700, color: .gray900)
+                                }
+                                VStack(alignment: .leading, spacing: .zero) {
+                                    TypographyText(text: "평균 페이스", style: .c1_400, color: .gray500)
+                                    TypographyText(text: store.detail.avgPaceText, style: .t1_700, color: .gray900)
+                                }
                             }
-                            VStack(alignment: .leading, spacing: .zero) {
-                                TypographyText(text: "평균 케이던스", style: .c1_400, color: .gray500)
-                                TypographyText(text: store.detail.cadenceText, style: .t1_700, color: .gray900)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                            VStack(alignment: .leading, spacing: 12) {
+                                VStack(alignment: .leading, spacing: .zero) {
+                                    TypographyText(text: "달린 시간", style: .c1_400, color: .gray500)
+                                    TypographyText(text: store.detail.durationText, style: .h1_700, color: .gray900)
+                                }
+                                VStack(alignment: .leading, spacing: .zero) {
+                                    TypographyText(text: "평균 케이던스", style: .c1_400, color: .gray500)
+                                    TypographyText(text: store.detail.cadenceText, style: .t1_700, color: .gray900)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 16)
+                        .background(Color.gray50)
+                        .cornerRadius(16)
+                        .padding(.bottom, 16)
+
+                        SquareRouteMap(
+                            points: store.detail.points,
+                            outerPadding: 20,
+                            data: $store.detail.mapImageData
+                        )
+                        .onAppear {
+                            store.send(.startImageCapture)
+                        }
+                        .onChange(of: store.detail.mapImageData) { _ in
+                            store.send(.getRouteImageData)
+                        }
+                        .cornerRadius(16)
+
+                        paceColorBar
+
+                        if store.isUploadable {
+                            recordVerificationButton {
+                                store.send(.recordVerificationButtonTapped)
                             }
                         }
-                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .padding(.horizontal, 20)
-                    .padding(.vertical, 16)
-                    .background(Color.gray50)
-                    .cornerRadius(16)
-                    .padding(.bottom, 16)
-                    
-                    SquareRouteMap(
-                        points: store.detail.points,
-                        outerPadding: 20,
-                        data: $store.detail.mapImageData
-                    )
-                    .onAppear {
-                        store.send(.startImageCapture)
-                    }
-                    .onChange(of: store.detail.mapImageData) { _ in
-                        store.send(.getRouteImageData)
-                    }
-                    .cornerRadius(16)
-                    .padding(.bottom, 8)
-                    
-                    paceColorBar
-                        .padding(.bottom, 32)
-
-                    if store.isUploadable {
-                        recordVerificationButton {
-                            store.send(.recordVerificationButtonTapped)
-                        }
-                    }
-                    
-                    Spacer()
                 }
-                .padding(.horizontal, 20)
                 
                 // MARK: - Image Capture Dim Overlay
                 if store.detail.mapImageURL == nil,
@@ -179,6 +177,8 @@ private extension RunningDetailView {
             
             TypographyText(text: "느림", style: .b2_700, color: .paceRed)
         }
+        .padding(.top, 8)
+        .padding(.bottom, 32)
     }
     
     func recordVerificationButton(action: @escaping () -> Void) -> some View {


### PR DESCRIPTION
# 변경 내용 요약
### RunningDetailView.swift - ScrollView 추가 및 레이아웃 통일
  - VStack을 ScrollView로 감싸서 SessionDetailView와 동일한 스크롤 구조로 변경
  - VStack(spacing: .zero) → VStack(alignment: .leading, spacing: 0) 으로 SessionDetailView와 동일하게 통일
  - Spacer() 제거 (ScrollView 내에서는 불필요)
  - paceColorBar의 패딩을 SessionDetailView와 동일하게 .padding(.top, 8).padding(.bottom, 32)로 설정

### RouteFitMapView.swift - 최대 줌 레벨 제한 추가
  - maxZoomLevel = 17 상수를 추가하여, fitCamera 후 줌 레벨이 17을 초과하면 17 제한
  - 짧은 거리 러닝 시 지도가 과도하게 확대되는 문제를 방지