### PR TITLE
[Fix] 러닝·세션 디테일에서 피드 업로드 시 광고 표시 오류 수정

### DIFF
--- a/DoRunDoRun/Sources/Presentation/Running/Running/Features/RunningFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Running/Running/Features/RunningFeature.swift
@@ -53,6 +53,7 @@ struct RunningFeature {
             case navigateToFriendProfile(userID: Int)
             case navigateBack
             case navigateToFeed
+            case feedUploadCompleted
         }
         case delegate(Delegate)
     }
@@ -197,7 +198,7 @@ struct RunningFeature {
                 
             case .runningDetail(.presented(.delegate(.feedUploadCompleted))):
                 state.runningDetail = nil
-                return .send(.delegate(.navigateToFeed))
+                return .send(.delegate(.feedUploadCompleted))
 
             default:
                 return .none

--- a/DoRunDoRun/Sources/Presentation/Running/SessionDetail/Features/SessionDetailFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Running/SessionDetail/Features/SessionDetailFeature.swift
@@ -55,6 +55,7 @@ struct SessionDetailFeature {
         // Delegate
         enum Delegate: Equatable {
             case navigateToMyProfile
+            case feedUploadCompleted
         }
         case delegate(Delegate)
     }
@@ -137,6 +138,10 @@ struct SessionDetailFeature {
                 // 세션 상세에서 인증 게시물을 보고 있을 때 내 프로필을 탭하면 sheet dismiss + delegate 전달
                 state.myFeedDetail = nil
                 return .send(.delegate(.navigateToMyProfile))
+
+            case .createFeed(.presented(.delegate(.uploadCompleted))):
+                state.createFeed = nil
+                return .send(.delegate(.feedUploadCompleted))
 
             case .createFeed(.presented(.backButtonTapped)):
                 state.createFeed = nil


### PR DESCRIPTION
# 수정 요약

  (3개 파일 수정)

### SessionDetailFeature.swift
  - Delegate에 feedUploadCompleted 추가
  - createFeed(.presented(.delegate(.uploadCompleted))) 핸들러 추가 — 업로드 완료 시 createFeed를 닫고 delegate를 상위로 전달

### RunningFeature.swift
  - Delegate에 feedUploadCompleted 추가
  - feedUploadCompleted 발생 시 기존 navigateToFeed 대신 feedUploadCompleted delegate를 전달하여 AppFeature에서 광고 표시 가능하도록 변경

### AppFeature.swift
  - AdSource enum 추가 — 광고 출처를 추적하여 광고 닫힌 후 적절한 네비게이션 처리
  - interstitialAdShown에서 출처별 분기:
    - feedSelectSession: feedPath pop + 피드 새로고침 (기존 동작)
    - runningDetail: 피드 탭 전환 + 피드 새로고침
    - sessionDetailFeed: feedPath pop + 피드 탭 전환 + 피드 새로고침
    - sessionDetailMy: myPath pop + 피드 탭 전환 + 피드 새로고침
  - 3개 경로에서 shouldShowInterstitialAd = true + adSource 설정 핸들러 추가