### PR TITLE
[Fix] 세션 디테일에서 인증 게시물 이미지가 표시되지 않던 문제 수정

### DIFF
--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/CreateFeed/Features/CreateFeedFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/CreateFeed/Features/CreateFeedFeature.swift
@@ -99,7 +99,7 @@ struct CreateFeedFeature {
                         runningID: String(state.session.id)
                     ))
                 )
-                
+
                 state.isUploading = true
 
                 // DTO에는 텍스트 데이터만 포함
@@ -107,13 +107,24 @@ struct CreateFeedFeature {
                     runSessionId: state.session.id,
                     content: "오늘도 완주!"
                 )
-                
+
                 let imageData = state.selectedImageData
+                let mapImageURL = state.session.mapImageURL
 
                 return .run { send in
                     do {
+                        // 선택된 이미지가 없으면 지도 이미지를 다운로드하여 전달
+                        let uploadImageData: Data?
+                        if let imageData {
+                            uploadImageData = imageData
+                        } else if let mapImageURL {
+                            uploadImageData = try? Data(contentsOf: mapImageURL)
+                        } else {
+                            uploadImageData = nil
+                        }
+
                         // 이미지 데이터는 별도 파라미터로 전달
-                        try await selfieFeedCreateUseCase.execute(data: dto, selfieImage: imageData)
+                        try await selfieFeedCreateUseCase.execute(data: dto, selfieImage: uploadImageData)
                         await send(.feedUploadSuccess)
                     } catch {
                         await send(.uploadFailure(error as? APIError ?? .unknown))

--- a/DoRunDoRun/Sources/Presentation/Running/SessionDetail/Views/SessionDetailView.swift
+++ b/DoRunDoRun/Sources/Presentation/Running/SessionDetail/Views/SessionDetailView.swift
@@ -244,7 +244,7 @@ private extension SessionDetailView {
                         .resizable()
                         .scaledToFill()
                         .frame(width: 50, height: 50)
-                        .cornerRadius(8)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
                 } else {
                     Rectangle()
                         .fill(Color.gray100)


### PR DESCRIPTION
# 수정 내용

### 파일: CreateFeedFeature.swift - 업로드 시 이미지 fallback 로직 추가

문제: 피드 업로드 시 사용자가 배경사진을 변경하지 않으면 selectedImageData가
nil이어서 서버에 이미지가 전달되지 않았습니다. 서버는 이미지를 null로 저장되고, 
세션 디테일의 "인증 게시물 보러가기" 버튼에서 이미지가 표시되지 않았습니다.

수정: selectedImageData가 nil일 때 session.mapImageURL에서 지도 이미지를 다운로드하여 대신 전달하도록 했습니다. 
이는 CreateFeedView와 CreateFeedCaptureView에서 이미지 미선택 시 지도 이미지를 보여주는 것과 동일한 동작입니다.