### PR TITLE
[Fix] 알림 목록에서 돌아올 때 알림 아이콘 상태가 갱신되지 않던 문제 수정

### DIFF
--- a/DoRunDoRun/Sources/App/AppFeature.swift
+++ b/DoRunDoRun/Sources/App/AppFeature.swift
@@ -360,7 +360,7 @@ struct AppFeature {
             // 피드 → 알림 목록 → 뒤로 가기
             case .feedPath(.element(id: _, action: .notificationList(.backButtonTapped))):
                 state.feedPath.removeLast()
-                return .none
+                return .send(.feed(.fetchUnreadCount))
 
             // 피드 → 알림 목록 → 친구 프로필로 이동 (친구 응원 알람을 탭한 경우)
             case let .feedPath(.element(id: _, action: .notificationList(.delegate(.navigateToFriendProfile(userID))))):


### PR DESCRIPTION
변경 내용: 알림 목록에서 뒤로가기 시 feedPath.removeLast() 이후 .send(.feed(.fetchUnreadCount))를 호출하여 
읽지 않은 알림 수를 서버에서 다시 조회하도록 했습니다.

이렇게 하면 알림 목록에서 알림을 읽은 후 피드 화면으로 돌아왔을 때, 
읽지 않은 알림이 0개이면 아이콘이 .alarm(비활성)으로 정상적으로 변경됩니다.