### PR TITLE
[Fix] 이미 가입된 번호 팝업 닫기 시 온보딩 첫 화면으로 바로 이동

### DIFF
--- a/DoRunDoRun/Sources/Presentation/Onboarding/Onboarding/Features/OnboardingFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Onboarding/Onboarding/Features/OnboardingFeature.swift
@@ -144,8 +144,13 @@ struct OnboardingFeature {
                 return .none
                 
             case .path(.element(id: _, action: .phoneAuth(.findAccountButtonTapped))):
-                // 로그인 화면에서 계정찾기 버튼 → 계정찾기 화면으로 이동
+                // 계정찾기 버튼 → 계정찾기 화면으로 이동
                 state.path.append(.findAccount(FindAccountFeature.State()))
+                return .none
+
+            case .path(.element(id: _, action: .phoneAuth(.existingAccountPopupDismissed))):
+                // 이미 가입된 번호 팝업에서 닫기 → 온보딩 첫 화면으로 돌아감
+                state.path.removeAll()
                 return .none
                 
             case let .path(.element(id: id, action: .phoneAuth(.backButtonTapped))):

--- a/DoRunDoRun/Sources/Presentation/Onboarding/VerifyPhone/Features/VerifyPhoneFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Onboarding/VerifyPhone/Features/VerifyPhoneFeature.swift
@@ -56,6 +56,7 @@ struct VerifyPhoneFeature {
         case signupButtonTapped
         case findAccountButtonTapped
         case backButtonTapped
+        case existingAccountPopupDismissed
     }
     
     var body: some ReducerOf<Self> {
@@ -213,7 +214,7 @@ struct VerifyPhoneFeature {
                     }
                 )
                 
-            case .testCompleted, .completed, .backButtonTapped:
+            case .testCompleted, .completed, .backButtonTapped, .existingAccountPopupDismissed:
                 return .cancel(id: TimerFeature.CancelID.timer)
                 
             default:

--- a/DoRunDoRun/Sources/Presentation/Onboarding/VerifyPhone/Views/VerifyPhoneView.swift
+++ b/DoRunDoRun/Sources/Presentation/Onboarding/VerifyPhone/Views/VerifyPhoneView.swift
@@ -198,8 +198,13 @@ private extension VerifyPhoneView {
                 Color.dimLight
                     .ignoresSafeArea()
                     .onTapGesture {
-                        focusedField = .verificationCode
+                        let action = store.popup.action
                         store.send(.popup(.hide))
+                        if action == .findAccount {
+                            store.send(.existingAccountPopupDismissed)
+                        } else {
+                            focusedField = .verificationCode
+                        }
                     }
 
                 ActionPopupView(
@@ -221,8 +226,13 @@ private extension VerifyPhoneView {
                         }
                     },
                     onCancel: {
-                        focusedField = .verificationCode
+                        let action = store.popup.action
                         store.send(.popup(.hide))
+                        if action == .findAccount {
+                            store.send(.existingAccountPopupDismissed)
+                        } else {
+                            focusedField = .verificationCode
+                        }
                     }
                 )
             }


### PR DESCRIPTION
# 수정 내용 요약
  파일: VerifyPhoneFeature.swift
  변경: existingAccountPopupDismissed 액션 추가
  ────────────────────────────────────────
  파일: VerifyPhoneView.swift
  변경: 팝업 "닫기" 및 딤 영역 탭 시 existingAccountPopupDismissed 전송
  ────────────────────────────────────────
  파일: OnboardingFeature.swift
  변경: 해당 액션 수신 시 state.path.removeAll()로 처음 화면 복귀
  동작 변경
  - 기존: "이미 가입된 번호" 팝업에서 닫기 → VerifyPhoneView에 잔류 → 뒤로가기
  여러 번 필요
  - 변경 후: "이미 가입된 번호" 팝업에서 닫기/딤 탭 → 온보딩 첫 화면으로 바로 이동

  로그인 플로우의 "아직 가입하지 않은 번호" 팝업은 기존과 동일하게 닫기 시 현재 화면에 잔류합니다.