### PR TITLE
[Fix] 약관 전체 동의가 먼저 활성화되도록 체크박스 인터랙션 개선

### DIFF
--- a/DoRunDoRun/Sources/Presentation/Onboarding/AgreeTerms/Features/AgreeTermsListFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Onboarding/AgreeTerms/Features/AgreeTermsListFeature.swift
@@ -27,14 +27,19 @@ struct AgreeTermsListFeature {
     enum Action: Equatable {
         // 하위 피처
         case agreeTermsRows(IdentifiedActionOf<AgreeTermsRowFeature>)
-        
+
         // 내부 동작
         case toggleAllAgreements(Bool)
-        
+        case setAllRowsAgreement(Bool)
+
         enum Delegate: Equatable {
             case openWebView(String)
         }
         case delegate(Delegate)
+    }
+
+    private enum CancelID {
+        case toggleAll
     }
 
     var body: some ReducerOf<Self> {
@@ -43,6 +48,13 @@ struct AgreeTermsListFeature {
                 
             case let .toggleAllAgreements(isOn):
                 state.isAllAgreed = isOn
+                return .run { send in
+                    try await Task.sleep(for: .milliseconds(100))
+                    await send(.setAllRowsAgreement(isOn))
+                }
+                .cancellable(id: CancelID.toggleAll, cancelInFlight: true)
+
+            case let .setAllRowsAgreement(isOn):
                 for id in state.agreeTermsRows.ids {
                     state.agreeTermsRows[id: id]?.isOn = isOn
                 }


### PR DESCRIPTION
 # 수정 내용 요약

 - toggleAllAgreements 액션에서 isAllAgreed만 즉시 업데이트하고, 
 하위 row들의 상태 변경은 setAllRowsAgreement 액션으로 분리하여 50ms 딜레이 후 적용되도록 변경했습니다.
  - cancelInFlight: true로 빠르게 연타할 경우 이전 Effect가 취소되어 상태 꼬임 방지합니다.

이렇게 하면 "약관 전체 동의" 체크박스가 먼저 활성화되고, 이후 하위 약관 체크박스들이 따라서 활성화됩니다.