### PR TITLE
[Feat] 피드 업로드 플로우 개선 및 수기 기록 기능 추가

### DIFF
--- a/DoRunDoRun/Sources/App/AppFeature.swift
+++ b/DoRunDoRun/Sources/App/AppFeature.swift
@@ -476,6 +476,12 @@ struct AppFeature {
                 state.feedPath.removeLast()
                 return .none
 
+            // 수기 기록 → 피드 생성 → 업로드 완료 → 광고 표시
+            case .feedPath(.element(_, .enterManualSession(.delegate(.feedUploadCompleted)))):
+                state.shouldShowInterstitialAd = true
+                state.adSource = .feedSelectSession
+                return .none
+
             // 피드 → 세션 상세 → 피드 업로드 완료 → 광고 표시
             case .feedPath(.element(_, .mySessionDetail(.delegate(.feedUploadCompleted)))):
                 state.shouldShowInterstitialAd = true

--- a/DoRunDoRun/Sources/App/AppFeature.swift
+++ b/DoRunDoRun/Sources/App/AppFeature.swift
@@ -245,6 +245,12 @@ struct AppFeature {
             case .feed(.delegate(.navigateToSelectSession)):
                 state.feedPath.append(.selectSession(SelectSessionFeature.State()))
                 return .none
+                
+            // 직접 기록 입력 (플로팅 버튼 탭 시)
+            case .feed(.delegate(.navigateToEnterManualSession)):
+                state.feedPath.append(.enterManualSession(EnterManualSessionFeature.State()))
+                return .none
+
 
             // 뒤로가기
             case .feed(.delegate(.navigateBack)):
@@ -465,6 +471,10 @@ struct AppFeature {
                 state.shouldShowInterstitialAd = true
                 state.adSource = .feedSelectSession
                 return .none
+                
+            case .feedPath(.element(id: _, action: .enterManualSession(.backButtonTapped))):
+                state.feedPath.removeLast()
+                return .none
 
             // 피드 → 세션 상세 → 피드 업로드 완료 → 광고 표시
             case .feedPath(.element(_, .mySessionDetail(.delegate(.feedUploadCompleted)))):
@@ -588,6 +598,7 @@ struct AppFeature {
         case feedDetail(FeedDetailFeature)                          // 피드 상세
         case editMyFeedDetail(EditFeedDetailFeature)                // 피드 수정
         case selectSession(SelectSessionFeature)                    // 세션 선택 (피드 업로드)
+        case enterManualSession(EnterManualSessionFeature)          // 세션 직접 기록 (피드 업로드)
         case mySessionDetail(SessionDetailFeature)                  // 내 세션 상세
     }
 

--- a/DoRunDoRun/Sources/App/AppView.swift
+++ b/DoRunDoRun/Sources/App/AppView.swift
@@ -75,6 +75,7 @@ struct MainTabView: View {
                     case .feedDetail(let store): FeedDetailView(store: store)
                     case .editMyFeedDetail(let store): EditMyFeedDetailView(store: store)
                     case .selectSession(let store): SelectSessionView(store: store)
+                    case .enterManualSession(let store): EnterManualSessionView(store: store)
                     case .mySessionDetail(let store): SessionDetailView(store: store)
                     }
                 }

--- a/DoRunDoRun/Sources/Common/Managers/RunningConverterManager.swift
+++ b/DoRunDoRun/Sources/Common/Managers/RunningConverterManager.swift
@@ -5,27 +5,95 @@
 //  Created by zaehorang on 11/17/25.
 //
 
+import Foundation
+
+/// 러닝 도메인에서 사용되는 단위 변환 유틸리티
+///
+/// - View 포맷과는 분리된 순수 계산 로직을 담당합니다.
+/// - UI 문자열 포맷은 RunningFormatterManager에서 처리합니다.
+/// - Feature에서는 직접 계산하지 않고 이 Converter를 호출해야 합니다.
 enum RunningConverterManager {
-    /// m → km
+    
+    // MARK: - Distance
+    
+    /// meters → kilometers
+    ///
+    /// 서버 또는 내부 계산 단위(m)를
+    /// UI 표시용 km(Double)로 변환합니다.
     static func metersToKilometers(_ meters: Double) -> Double {
         meters / 1000
     }
+    
+    /// km.xx 입력값 → meters(Int)
+    ///
+    /// 예:
+    /// 5km + 25(=0.25km) → 5250m
+    ///
+    /// 수기 입력 화면에서 받은 정수/소수 부분을
+    /// 서버 요청용 meters 단위로 변환합니다.
+    static func kmToMeters(whole: Int, decimal: Int) -> Int {
+        whole * 1000 + decimal * 10
+    }
 
-    /// sec → (h, m, s)
+    
+    // MARK: - Duration
+    
+    /// seconds → (hour, minute, second)
+    ///
+    /// 서버 응답값(seconds)을
+    /// 시간/분/초 구조로 분리할 때 사용합니다.
     static func secondsToHMS(_ seconds: Int) -> (h: Int, m: Int, s: Int) {
         let hours = seconds / 3600
         let minutes = (seconds % 3600) / 60
         let secs = seconds % 60
         return (hours, minutes, secs)
     }
+    
+    /// DateComponents(h/m/s) → total seconds
+    ///
+    /// 예:
+    /// 1시간 2분 30초 → 3750초
+    ///
+    /// 수기 입력 화면에서 받은 시간 컴포넌트를
+    /// 서버 요청용 seconds로 변환합니다.
+    static func hmsToSeconds(_ components: DateComponents) -> Int {
+        (components.hour ?? 0) * 3600 +
+        (components.minute ?? 0) * 60 +
+        (components.second ?? 0)
+    }
 
+    
+    // MARK: - Pace
+    
     /// m/s → sec/km
+    ///
+    /// 평균 속도(m/s)를
+    /// 1km당 걸린 시간(seconds)으로 변환합니다.
+    ///
+    /// speed가 0 이하인 경우 nil 반환
     static func speedToPace(_ speed: Double) -> Double? {
         guard speed > 0 else { return nil }
         return 1000 / speed
     }
+    
+    /// minute/second → total seconds
+    ///
+    /// 예:
+    /// 4분 30초 → 270초
+    ///
+    /// 수기 입력 페이스를
+    /// 내부 계산/서버 전송용 초 단위로 변환합니다.
+    static func paceToSeconds(minute: Int, second: Int) -> Int {
+        minute * 60 + second
+    }
 
+    
+    // MARK: - Cadence
+    
     /// spm(Double) → spm(Int)
+    ///
+    /// 서버 또는 계산 과정에서 Double로 존재하는 cadence를
+    /// UI 및 내부 정수 단위로 변환합니다.
     static func cadenceToInt(_ spm: Double) -> Int {
         Int(spm)
     }

--- a/DoRunDoRun/Sources/Common/Managers/RunningFormatterManager.swift
+++ b/DoRunDoRun/Sources/Common/Managers/RunningFormatterManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 final class RunningFormatterManager {
+
     // MARK: - Distance
     func formatDistance(from meters: Double) -> String {
         let km = RunningConverterManager.metersToKilometers(meters)
@@ -22,15 +23,26 @@ final class RunningFormatterManager {
             : String(format: "%02d:%02d", m, s)
     }
     
-    // MARK: - Pace
+    // MARK: - Pace (m/s 기반)
     func formatPace(from speed: Double) -> String {
         guard let secPerKm = RunningConverterManager.speedToPace(speed) else { return "0'00\"" }
         let pace = Int(secPerKm)
         return String(format: "%d'%02d\"", pace / 60, pace % 60)
     }
     
-    // MARK: - Cadence
+    // MARK: - Pace (seconds 기반)
+    func formatPaceFromSeconds(_ seconds: Int) -> String {
+        guard seconds > 0 else { return "0'00\"" }
+        return String(format: "%d'%02d\"", seconds / 60, seconds % 60)
+    }
+    
+    // MARK: - Cadence (Double 기반)
     func formatCadence(from spm: Double) -> String {
         "\(RunningConverterManager.cadenceToInt(spm)) spm"
+    }
+    
+    // MARK: - Cadence (Int 기반)
+    func formatCadenceFromInt(_ spm: Int) -> String {
+        "\(spm) spm"
     }
 }

--- a/DoRunDoRun/Sources/Data/API/RunningAPI.swift
+++ b/DoRunDoRun/Sources/Data/API/RunningAPI.swift
@@ -15,6 +15,7 @@ enum RunningAPI {
     case complete(sessionId: Int, data: RunningCompleteRequestDTO, mapImage: Data?)
     case sessions(isSelfied: Bool?, startDateTime: String?, endDateTime: String?)
     case sessionDetail(sessionId: Int)
+    case manualComplete(request: ManualSessionRequestDTO)
 }
 
 extension RunningAPI: TargetType {
@@ -32,12 +33,14 @@ extension RunningAPI: TargetType {
             return "/api/runs/sessions"
         case .sessionDetail(let sessionId):
             return "/api/runs/sessions/\(sessionId)"
+        case .manualComplete:
+            return "/api/runs/sessions/manual/complete"
         }
     }
 
     var method: Moya.Method {
         switch self {
-        case .start, .saveSegments, .complete:
+        case .start, .saveSegments, .complete, .manualComplete:
             return .post
         case .sessions, .sessionDetail:
             return .get
@@ -103,6 +106,9 @@ extension RunningAPI: TargetType {
         case .sessionDetail:
             // Path parameter만 사용
             return .requestPlain
+
+        case let .manualComplete(request):
+            return .requestJSONEncodable(request)
         }
     }
 

--- a/DoRunDoRun/Sources/Data/DTO/Running/ManualSessionRequestDTO.swift
+++ b/DoRunDoRun/Sources/Data/DTO/Running/ManualSessionRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  ManualSessionRequestDTO.swift
+//  DoRunDoRun
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+
+struct ManualSessionRequestDTO: Encodable {
+    let startedAt: String   // ISO8601
+    let durationTotal: Int  // 초
+    let distanceTotal: Int  // 미터
+    let paceAvg: Int        // 초/km
+    let cadenceAvg: Int     // spm
+}

--- a/DoRunDoRun/Sources/Data/DTO/Running/ManualSessionResponseDTO.swift
+++ b/DoRunDoRun/Sources/Data/DTO/Running/ManualSessionResponseDTO.swift
@@ -1,0 +1,43 @@
+//
+//  ManualSessionResponseDTO.swift
+//  DoRunDoRun
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+
+struct ManualSessionResponseDTO: Decodable {
+    let status: String
+    let message: String
+    let timestamp: String
+    let data: ManualSessionDataDTO
+}
+
+struct ManualSessionDataDTO: Decodable, Equatable {
+    let id: Int
+    let finishedAt: String
+    let durationTotal: Int
+    let distanceTotal: Int
+    let paceAvg: Int
+    let cadenceAvg: Int
+}
+
+// MARK: - Mapping to Domain
+extension ManualSessionDataDTO {
+    func toDomain() -> RunningSessionSummary {
+        let parser = DateFormatterManager.shared
+        
+        return RunningSessionSummary(
+            sessionId: id,
+            createdAt: parser.isoDate(from: finishedAt) ?? Date(),
+            finishedAt: parser.isoDate(from: finishedAt) ?? Date(),
+            totalDistanceMeters: Double(distanceTotal),
+            totalDurationSeconds: durationTotal,
+            avgPaceSecPerKm: Double(paceAvg),
+            avgCadenceSpm: Double(cadenceAvg),
+            isSelfied: false,
+            mapImageURL: nil
+        )
+    }
+}

--- a/DoRunDoRun/Sources/Data/RepositoryImpl/Running/RunningSessionRepositoryImpl.swift
+++ b/DoRunDoRun/Sources/Data/RepositoryImpl/Running/RunningSessionRepositoryImpl.swift
@@ -99,6 +99,15 @@ final class RunningSessionRepositoryImpl: RunningSessionRepository {
             RunningAPI.sessionDetail(sessionId: sessionId),
             responseType: RunningSessionDetailResponseDTO.self
         )
+
+        return response.data.toDomain()
+    }
+
+    func createManualSession(request: ManualSessionRequestDTO) async throws -> RunningSessionSummary {
+        let response = try await apiClient.request(
+            RunningAPI.manualComplete(request: request),
+            responseType: ManualSessionResponseDTO.self
+        )
         
         return response.data.toDomain()
     }

--- a/DoRunDoRun/Sources/Data/RepositoryMock/Running/RunningSessionRepositoryMock.swift
+++ b/DoRunDoRun/Sources/Data/RepositoryMock/Running/RunningSessionRepositoryMock.swift
@@ -60,4 +60,9 @@ final class RunningSessionRepositoryMock: RunningSessionRepository {
         // Mock 상세 정보 반환
         return RunningDetail.mock
     }
+
+    func createManualSession(request: ManualSessionRequestDTO) async throws -> RunningSessionSummary {
+        // Mock 세션 반환
+        return RunningSessionSummary.mock
+    }
 }

--- a/DoRunDoRun/Sources/Domain/Repository/Running/RunningSessionRepository.swift
+++ b/DoRunDoRun/Sources/Domain/Repository/Running/RunningSessionRepository.swift
@@ -55,4 +55,11 @@ protocol RunningSessionRepository: AnyObject {
     /// - Parameter sessionId: 세션 ID
     /// - Returns: 러닝 상세 정보
     func fetchSessionDetail(sessionId: Int) async throws -> RunningDetail
+
+    /// 수기 러닝 세션 생성
+    /// - Parameter request: 수기 세션 요청 데이터
+    /// - Returns: 러닝 세션 요약 목록
+    func createManualSession(
+        request: ManualSessionRequestDTO
+    ) async throws -> RunningSessionSummary
 }

--- a/DoRunDoRun/Sources/Domain/UseCase/Running/ManualSessionCreator.swift
+++ b/DoRunDoRun/Sources/Domain/UseCase/Running/ManualSessionCreator.swift
@@ -1,0 +1,24 @@
+//
+//  ManualSessionCreator.swift
+//  DoRunDoRun
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+
+protocol ManualSessionCreatorProtocol {
+    func execute(request: ManualSessionRequestDTO) async throws -> RunningSessionSummary
+}
+
+final class ManualSessionCreator: ManualSessionCreatorProtocol {
+    private let sessionRepository: RunningSessionRepository
+
+    init(sessionRepository: RunningSessionRepository) {
+        self.sessionRepository = sessionRepository
+    }
+
+    func execute(request: ManualSessionRequestDTO) async throws -> RunningSessionSummary {
+        try await sessionRepository.createManualSession(request: request)
+    }
+}

--- a/DoRunDoRun/Sources/Presentation/Feed/Feed/Features/FeedFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/Feed/Features/FeedFeature.swift
@@ -59,6 +59,8 @@ struct FeedFeature {
         func extraReactionCount(for feed: SelfieFeedItem) -> Int {
             max(0, feed.reactions.count - 3)
         }
+        
+        var isFabExpanded = false
     }
 
     // MARK: - Action
@@ -118,7 +120,10 @@ struct FeedFeature {
         case showReportPopup(Int)
         case confirmReport(Int)
         
-        case uploadButtonTapped
+        case fabTapped
+        case dismissFab
+        case entryMenuSelectSessionTapped
+        case entryMenuEnterManualSessionTapped
         
         case toast(ToastFeature.Action)
         case popup(PopupFeature.Action)
@@ -140,6 +145,7 @@ struct FeedFeature {
             case navigateToFeedDetail(feedID: Int, feed: SelfieFeedItem)
             case navigateToEditFeed(feed: SelfieFeedItem)
             case navigateToSelectSession
+            case navigateToEnterManualSession
             case navigateBack
         }
         case delegate(Delegate)
@@ -511,7 +517,15 @@ struct FeedFeature {
                 return .none
               
             // MARK: - 피드 업로드 버튼 탭
-            case .uploadButtonTapped:
+            case .fabTapped:
+                state.isFabExpanded.toggle()
+                return .none
+
+            case .dismissFab:
+                state.isFabExpanded = false
+                return .none
+                
+            case .entryMenuSelectSessionTapped:
                 // event
                 // Entry / Upload / Result 이벤트는 CreateFeedFeature에서 처리
                 analytics.track(
@@ -521,6 +535,17 @@ struct FeedFeature {
                     ))
                 )
                 return .send(.delegate(.navigateToSelectSession))
+
+            case .entryMenuEnterManualSessionTapped:
+                // event
+                // Entry / Upload / Result 이벤트는 CreateFeedFeature에서 처리
+                analytics.track(
+                    .feed(.createFeedCtaClicked(
+                        source: .feedFab,
+                        runningID: nil
+                    ))
+                )
+                return .send(.delegate(.navigateToEnterManualSession))
                 
             // MARK: - 실패한 로직 저장
             case let .setLastFailedRequest(request):

--- a/DoRunDoRun/Sources/Presentation/Feed/Feed/Features/FeedFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/Feed/Features/FeedFeature.swift
@@ -61,6 +61,8 @@ struct FeedFeature {
         }
         
         var isFabExpanded = false
+        var isTodayCertified = false
+        var isCertificationCompletedPopupVisible = false
     }
 
     // MARK: - Action
@@ -124,6 +126,7 @@ struct FeedFeature {
         case dismissFab
         case entryMenuSelectSessionTapped
         case entryMenuEnterManualSessionTapped
+        case dismissCertificationCompletedPopup
         
         case toast(ToastFeature.Action)
         case popup(PopupFeature.Action)
@@ -277,7 +280,11 @@ struct FeedFeature {
             // 조회 성공
             case let .fetchSelfieUsersSuccess(users):
                 state.isLoadingUsers = false
-                state.selfieUsers = SelfieUserViewStateMapper.mapList(from: users)
+                let mapped = SelfieUserViewStateMapper.mapList(from: users)
+                state.selfieUsers = mapped
+                if calendar.isDateInToday(state.selectedDate) {
+                    state.isTodayCertified = mapped.contains { $0.isMe }
+                }
                 return .none
                 
             // 조회 실패
@@ -518,11 +525,19 @@ struct FeedFeature {
               
             // MARK: - 피드 업로드 버튼 탭
             case .fabTapped:
-                state.isFabExpanded.toggle()
+                if !state.isFabExpanded && state.isTodayCertified {
+                    state.isCertificationCompletedPopupVisible = true
+                } else {
+                    state.isFabExpanded.toggle()
+                }
                 return .none
 
             case .dismissFab:
                 state.isFabExpanded = false
+                return .none
+
+            case .dismissCertificationCompletedPopup:
+                state.isCertificationCompletedPopupVisible = false
                 return .none
                 
             case .entryMenuSelectSessionTapped:

--- a/DoRunDoRun/Sources/Presentation/Feed/Feed/Views/FeedView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/Feed/Views/FeedView.swift
@@ -186,33 +186,74 @@ private extension FeedView {
 // MARK: - Floating Upload Button Section
 private extension FeedView {
     /// Floating Upload Button Section
-    var floatingUploadButtonSection: some View {
-        HStack {
-            Spacer()
-            Button {
-                store.send(.uploadButtonTapped)
-            } label: {
-                Image(.add, size: .medium)
-                    .renderingMode(.template)
-                    .foregroundStyle(Color.gray0)
-                    .frame(width: 52, height: 52)
-                    .background(
-                        Circle()
-                            .fill(Color.blue600)
-                            .shadow(
-                                color: Color.gray900.opacity(0.15),
-                                radius: 12,
-                                x: 0,
-                                y: 2
-                            )
-                    )
+    private var floatingUploadButtonSection: some View {
+        ZStack {
+            // 배경 dim
+            if store.isFabExpanded {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        store.send(.dismissFab)
+                    }
+                    .transition(.opacity)
             }
+
+            VStack(alignment: .trailing, spacing: 12) {
+                if store.isFabExpanded {
+                    VStack(alignment: .leading, spacing: 8) {
+                        fabActionButton(
+                            title: "기록 불러오기",
+                        ) {
+                            store.send(.entryMenuSelectSessionTapped)
+                        }
+                        
+                        fabActionButton(
+                            title: "직접 기록 입력하기",
+                        ) {
+                            store.send(.entryMenuEnterManualSessionTapped)
+                        }
+
+                    }
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.gray0)
+                    )
+                }
+
+                // 메인 FAB
+                Button {
+                    store.send(.fabTapped)
+                } label: {
+                    Image(.add, size: .medium)
+                        .renderingMode(.template)
+                        .foregroundColor(store.isFabExpanded ? Color.gray600 : Color.gray0)
+                        .frame(width: 52, height: 52)
+                        .background(Circle().fill(store.isFabExpanded ? Color.gray0 : Color.blue600))
+                        .shadow(radius: 8)
+                        .rotationEffect(.degrees(store.isFabExpanded ? 45 : 0))
+                        .animation(.spring(response: 0.3, dampingFraction: 0.7),
+                                   value: store.isFabExpanded)
+                }
+            }
+            .padding(.trailing, 20)
+            .padding(.bottom, 24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
         }
-        .padding(.horizontal, 20)
-        .padding(.bottom, 16)
-        .transition(.scale.combined(with: .opacity))
-        .animation(.spring(response: 0.3, dampingFraction: 0.8),
-                   value: store.isReactionDetailPresented || store.isReactionPickerPresented)
+    }
+    
+    private func fabActionButton(
+        title: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 0) {
+                TypographyText(text: title, style: .b1_500, color: .gray700)
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 16)
+        }
+        .transition(.move(edge: .trailing).combined(with: .opacity))
     }
 }
 

--- a/DoRunDoRun/Sources/Presentation/Feed/Feed/Views/FeedView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/Feed/Views/FeedView.swift
@@ -12,6 +12,7 @@ struct FeedView: View {
                 floatingUploadButtonSection
                 toastSection
                 popupSection
+                certificationCompletedPopupSection
                 networkErrorPopupSection
             }
             .onAppear { store.send(.onAppear) }
@@ -307,6 +308,33 @@ private extension FeedView {
             }
             .transition(.opacity.combined(with: .scale))
             .zIndex(20)
+        }
+    }
+}
+
+// MARK: - Certification Completed Popup Section
+private extension FeedView {
+    @ViewBuilder
+    var certificationCompletedPopupSection: some View {
+        if store.isCertificationCompletedPopupVisible {
+            ZStack {
+                Color.dimLight
+                    .ignoresSafeArea()
+                    .onTapGesture { store.send(.dismissCertificationCompletedPopup) }
+
+                ActionPopupView(
+                    image: Image(.certificationCompleted),
+                    title: "오늘은 이미 기록을 인증했어요!",
+                    message: "인증은 하루에 1회 진행할 수 있어요.\n내일도 함께 달려요!",
+                    actionTitle: "확인",
+                    cancelTitle: nil,
+                    style: .actionOnly,
+                    onAction: { store.send(.dismissCertificationCompletedPopup) },
+                    onCancel: nil
+                )
+            }
+            .transition(.opacity.combined(with: .scale))
+            .zIndex(15)
         }
     }
 }

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Features/EnterManualSessionFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Features/EnterManualSessionFeature.swift
@@ -1,0 +1,58 @@
+//
+//  EnterManualSessionFeature.swift
+//  DoRunDoRun
+//
+//  Created by Jaehui Yu on 2/10/26.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct EnterManualSessionFeature {
+
+    // MARK: - State
+
+    @ObservableState
+    struct State: Equatable {
+
+        var startTime: Date? = nil
+        var duration: DateComponents? = nil
+        var distanceWhole: Int? = nil
+        var distanceDecimal: Int? = nil
+        var paceMinute: Int? = nil
+        var paceSecond: Int? = nil
+        var cadence: String = ""
+
+        var isRequiredFieldsFilled: Bool {
+            startTime != nil &&
+            duration != nil &&
+            distanceWhole != nil &&
+            distanceDecimal != nil
+        }
+    }
+
+    // MARK: - Action
+
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        case addButtonTapped
+    }
+
+    // MARK: - Reducer
+
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+                
+            case .addButtonTapped:
+                return .none
+
+            case .binding:
+                return .none
+            }
+        }
+    }
+}

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Features/EnterManualSessionFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Features/EnterManualSessionFeature.swift
@@ -37,6 +37,7 @@ struct EnterManualSessionFeature {
     enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
         case addButtonTapped
+        case backButtonTapped
     }
 
     // MARK: - Reducer
@@ -48,6 +49,9 @@ struct EnterManualSessionFeature {
             switch action {
                 
             case .addButtonTapped:
+                return .none
+                
+            case .backButtonTapped:
                 return .none
 
             case .binding:

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Features/EnterManualSessionFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Features/EnterManualSessionFeature.swift
@@ -11,11 +11,14 @@ import ComposableArchitecture
 @Reducer
 struct EnterManualSessionFeature {
 
-    // MARK: - State
+    // MARK: - Dependencies
+    @Dependency(\.manualSessionCreator) var manualSessionCreator
+    @Dependency(\.analyticsTracker) var analytics
 
+    // MARK: - State
     @ObservableState
     struct State: Equatable {
-
+        var isLoading: Bool = false
         var startTime: Date? = nil
         var duration: DateComponents? = nil
         var distanceWhole: Int? = nil
@@ -23,40 +26,145 @@ struct EnterManualSessionFeature {
         var paceMinute: Int? = nil
         var paceSecond: Int? = nil
         var cadence: String = ""
-
         var isRequiredFieldsFilled: Bool {
             startTime != nil &&
             duration != nil &&
             distanceWhole != nil &&
             distanceDecimal != nil
         }
+        var networkErrorPopup = NetworkErrorPopupFeature.State()
+        var serverError = ServerErrorFeature.State()
+        @Presents var createFeed: CreateFeedFeature.State?
+
     }
 
     // MARK: - Action
-
     enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
         case addButtonTapped
         case backButtonTapped
+        case createManualSessionSuccess(RunningSessionSummary)
+        case createManualSessionFailure(APIError)
+
+        // 에러 관련
+        case networkErrorPopup(NetworkErrorPopupFeature.Action)
+        case serverError(ServerErrorFeature.Action)
+
+        // Navigation
+        case createFeed(PresentationAction<CreateFeedFeature.Action>)
+
+        enum DelegateAction: Equatable {
+            case feedUploadCompleted
+        }
+        case delegate(DelegateAction)
     }
 
     // MARK: - Reducer
 
     var body: some ReducerOf<Self> {
         BindingReducer()
+        
+        Scope(state: \.networkErrorPopup, action: \.networkErrorPopup) { NetworkErrorPopupFeature() }
+        Scope(state: \.serverError, action: \.serverError) { ServerErrorFeature() }
 
         Reduce { state, action in
             switch action {
                 
+            // MARK: - 추가하기 버튼 탭
             case .addButtonTapped:
+                guard let startTime = state.startTime,
+                      let duration = state.duration,
+                      let distanceWhole = state.distanceWhole,
+                      let distanceDecimal = state.distanceDecimal else {
+                    return .none
+                }
+
+                state.isLoading = true
+
+                // ISO8601 변환
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                let startedAt = formatter.string(from: startTime)
+
+                // 단위 변환
+                let durationTotal = RunningConverterManager.hmsToSeconds(duration)
+                let distanceTotal = RunningConverterManager.kmToMeters(
+                    whole: distanceWhole,
+                    decimal: distanceDecimal
+                )
+                let paceAvg = RunningConverterManager.paceToSeconds(
+                    minute: state.paceMinute ?? 0,
+                    second: state.paceSecond ?? 0
+                )
+                let cadenceAvg = Int(state.cadence) ?? 0
+
+                let request = ManualSessionRequestDTO(
+                    startedAt: startedAt,
+                    durationTotal: durationTotal,
+                    distanceTotal: distanceTotal,
+                    paceAvg: paceAvg,
+                    cadenceAvg: cadenceAvg
+                )
+
+                return .run { send in
+                    do {
+                        let data = try await manualSessionCreator.execute(request: request)
+                        await send(.createManualSessionSuccess(data))
+                    } catch {
+                        await send(.createManualSessionFailure(error as? APIError ?? .unknown))
+                    }
+                }
+
+            // MARK: - 생성 성공
+            case let .createManualSessionSuccess(entity):
+                state.isLoading = false
+
+                let mapper = RunningSessionSummaryViewStateMapper()
+                guard let session = mapper.map(from: [entity]).first else { return .none }
+
+                state.createFeed = .init(
+                    entryPoint: .inputManual,
+                    session: session
+                )
+
                 return .none
-                
+
+            // MARK: - 생성 실패
+            case let .createManualSessionFailure(error):
+                state.isLoading = false
+                return handleAPIError(error)
+
             case .backButtonTapped:
                 return .none
 
             case .binding:
                 return .none
+
+            // MARK: - CreateFeed 델리게이트
+            case .createFeed(.presented(.delegate(.uploadCompleted))):
+                state.createFeed = nil
+                return .send(.delegate(.feedUploadCompleted))
+
+            case .createFeed(.presented(.backButtonTapped)):
+                state.createFeed = nil
+                return .none
+
+            default:
+                return .none
             }
+        }
+        .ifLet(\.$createFeed, action: \.createFeed) { CreateFeedFeature() }
+    }
+}
+
+private extension EnterManualSessionFeature {
+    func handleAPIError(_ apiError: APIError) -> Effect<Action> {
+        switch apiError {
+        case .networkError: return .send(.networkErrorPopup(.show))
+        case .notFound: return .send(.serverError(.show(.notFound)))
+        case .internalServer: return .send(.serverError(.show(.internalServer)))
+        case .badGateway: return .send(.serverError(.show(.badGateway)))
+        default: return .none
         }
     }
 }

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/DistancePickerRow.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/DistancePickerRow.swift
@@ -1,0 +1,110 @@
+//
+//  DistancePickerRow.swift
+//  DoRunDoRun
+//
+//  Created by Jaehui Yu on 2/19/26.
+//
+
+import SwiftUI
+
+struct DistancePickerRow: View {
+    let title: String
+    var required: Bool = false
+    var placeholder: String
+    @Binding var whole: Int?
+    @Binding var decimal: Int?
+
+    @State private var selectedWhole: Int = 1
+    @State private var selectedDecimal: Int = 0
+    @State private var isPresented = false
+
+    private var displayText: String {
+        guard let whole, let decimal else { return "" }
+        return String(format: "%d.%02d", whole, decimal)
+    }
+
+    var body: some View {
+
+        InputRow(title: title, required: required) {
+            Button {
+                isPresented = true
+            } label: {
+                HStack {
+                    if whole != nil && decimal != nil {
+                        TypographyText(
+                            text: displayText,
+                            style: .b1_500,
+                            color: .gray900
+                        )
+                    } else {
+                        TypographyText(
+                            text: placeholder,
+                            style: .b1_500,
+                            color: .gray300
+                        )
+                    }
+
+                    Spacer()
+
+                    TypographyText(text: "km", style: .b1_500)
+                }
+            }
+        }
+        .sheet(isPresented: $isPresented) {
+            NavigationStack {
+                VStack {
+
+                    HStack(spacing: 0) {
+
+                        // 정수 부분 (1~99)
+                        Picker("Whole", selection: $selectedWhole) {
+                            ForEach(1...99, id: \.self) {
+                                Text("\($0)").tag($0)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+
+                        Text(".")
+                            .font(.title2)
+                            .padding(.horizontal, 4)
+
+                        // 소수 부분 (00~99)
+                        Picker("Decimal", selection: $selectedDecimal) {
+                            ForEach(0...99, id: \.self) {
+                                Text(String(format: "%02d", $0)).tag($0)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                    }
+                    .frame(height: 200)
+
+                }
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("취소") {
+                            isPresented = false
+                        }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("완료") {
+                            whole = selectedWhole
+                            decimal = selectedDecimal
+                            isPresented = false
+                        }
+                    }
+                }
+            }
+            .presentationDetents([.height(300)])
+            .presentationDragIndicator(.visible)
+        }
+        .onAppear {
+            if let whole {
+                selectedWhole = whole
+            }
+            if let decimal {
+                selectedDecimal = decimal
+            }
+        }
+    }
+}

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/DurationPickerRow.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/DurationPickerRow.swift
@@ -1,0 +1,118 @@
+//
+//  DurationPickerRow.swift
+//  DoRunDoRun
+//
+//  Created by Jaehui Yu on 2/19/26.
+//
+
+import SwiftUI
+
+struct DurationPickerRow: View {
+    let title: String
+    var required: Bool = false
+    var placeholder: String
+    @Binding var selectedDuration: DateComponents?
+
+    @State private var hour: Int = 0
+    @State private var minute: Int = 0
+    @State private var second: Int = 0
+    @State private var isPresented = false
+
+    private var displayText: String {
+        guard let selectedDuration else { return "" }
+
+        let hh = selectedDuration.hour ?? 0
+        let mm = selectedDuration.minute ?? 0
+        let ss = selectedDuration.second ?? 0
+
+        return String(format: "%02d:%02d:%02d", hh, mm, ss)
+    }
+
+    var body: some View {
+
+        InputRow(title: title, required: required) {
+            Button {
+                isPresented = true
+            } label: {
+                HStack {
+                    if selectedDuration != nil {
+                        TypographyText(
+                            text: displayText,
+                            style: .b1_500,
+                            color: .gray900
+                        )
+                    } else {
+                        TypographyText(
+                            text: placeholder,
+                            style: .b1_500,
+                            color: .gray300
+                        )
+                    }
+
+                    Spacer()
+
+                    TypographyText(text: "시간", style: .b1_500)
+                }
+            }
+        }
+        .sheet(isPresented: $isPresented) {
+            NavigationStack {
+                VStack(spacing: 0) {
+
+                    HStack(spacing: 0) {
+
+                        Picker("Hour", selection: $hour) {
+                            ForEach(0..<24, id: \.self) {
+                                Text("\($0)시간").tag($0)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+
+                        Picker("Minute", selection: $minute) {
+                            ForEach(0..<60, id: \.self) {
+                                Text("\($0)분").tag($0)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+
+                        Picker("Second", selection: $second) {
+                            ForEach(0..<60, id: \.self) {
+                                Text("\($0)초").tag($0)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                    }
+                    .frame(height: 200)
+
+                }
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("취소") {
+                            isPresented = false
+                        }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("완료") {
+                            selectedDuration = DateComponents(
+                                hour: hour,
+                                minute: minute,
+                                second: second
+                            )
+                            isPresented = false
+                        }
+                    }
+                }
+            }
+            .presentationDetents([.height(300)])
+            .presentationDragIndicator(.visible)
+        }
+        .onAppear {
+            if let selectedDuration {
+                hour = selectedDuration.hour ?? 0
+                minute = selectedDuration.minute ?? 0
+                second = selectedDuration.second ?? 0
+            }
+        }
+    }
+}

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/EnterManualSessionView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/EnterManualSessionView.swift
@@ -79,6 +79,7 @@ struct EnterManualSessionView: View {
             .navigationTitle("직접 기록")
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden()
+            .toolbar(.hidden, for: .tabBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/EnterManualSessionView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/EnterManualSessionView.swift
@@ -78,6 +78,18 @@ struct EnterManualSessionView: View {
             .scrollDismissesKeyboard(.immediately)
             .navigationTitle("직접 기록")
             .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden()
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        store.send(.backButtonTapped)
+                    } label: {
+                        Image(.arrowLeft, size: .medium)
+                            .renderingMode(.template)
+                            .foregroundColor(.gray800)
+                    }
+                }
+            }
             .safeAreaInset(edge: .bottom) {
                 AppButton(
                     title: "추가하기",

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/EnterManualSessionView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/EnterManualSessionView.swift
@@ -1,0 +1,104 @@
+//
+//  EnterManualSessionView.swift
+//  DoRunDoRun
+//
+//  Created by Jaehui Yu on 2/10/26.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct EnterManualSessionView: View {
+
+    @Perception.Bindable var store: StoreOf<EnterManualSessionFeature>
+
+    var body: some View {
+        WithPerceptionTracking {
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 36) {
+
+                        // MARK: - 기본 정보
+                        VStack(alignment: .leading, spacing: 24) {
+                            TypographyText(text: "기본 정보", style: .t2_700)
+
+                            StartTimePickerRow(
+                                title: "러닝 시작 시간",
+                                required: true,
+                                placeholder: "오전 00:00",
+                                selectedDate: $store.startTime
+                            )
+
+                            DurationPickerRow(
+                                title: "러닝 소요 시간",
+                                required: true,
+                                placeholder: "00:00:00",
+                                selectedDuration: $store.duration
+                            )
+
+                            DistancePickerRow(
+                                title: "거리",
+                                required: true,
+                                placeholder: "00.00",
+                                whole: $store.distanceWhole,
+                                decimal: $store.distanceDecimal
+                            )
+                        }
+                        .padding(.horizontal, 20)
+
+                        // MARK: - 구분선
+                        Rectangle()
+                            .frame(height: 8)
+                            .foregroundStyle(Color.gray50)
+
+                        // MARK: - 상세 정보
+                        VStack(alignment: .leading, spacing: 24) {
+                            TypographyText(text: "상세 정보", style: .t2_700)
+
+                            PacePickerRow(
+                                title: "페이스",
+                                placeholder: "페이스 입력(선택)",
+                                minute: $store.paceMinute,
+                                second: $store.paceSecond
+                            )
+
+                            TextInputRow(
+                                title: "케이던스",
+                                placeholder: "케이던스 입력(선택)",
+                                unit: store.cadence.isEmpty ? nil : "spm",
+                                text: $store.cadence
+                            )
+                        }
+                        .padding(.horizontal, 20)
+
+                    }
+                    .padding(.top, 16)
+                }
+            }
+            .scrollDismissesKeyboard(.immediately)
+            .navigationTitle("직접 기록")
+            .navigationBarTitleDisplayMode(.inline)
+            .safeAreaInset(edge: .bottom) {
+                AppButton(
+                    title: "추가하기",
+                    style: store.isRequiredFieldsFilled ? .primary : .disabled,
+                    size: .fullWidth
+                ) {
+                    store.send(.addButtonTapped)
+                }
+                .disabled(!store.isRequiredFieldsFilled)
+                .padding(.horizontal, 20)
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        EnterManualSessionView(
+            store: Store(initialState: EnterManualSessionFeature.State()) {
+                EnterManualSessionFeature()
+            }
+        )
+    }
+}

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/InputRow.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/InputRow.swift
@@ -1,0 +1,43 @@
+//
+//  InputRow.swift
+//  DoRunDoRun
+//
+//  Created by Jaehui Yu on 2/10/26.
+//
+
+import SwiftUI
+
+struct InputRow<Content: View>: View {
+    let title: String
+    var required: Bool = false
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            RowTitle(title: title, required: required)
+
+            content()
+                .padding(.vertical, 8)
+                .overlay(
+                    Rectangle()
+                        .frame(height: 1)
+                        .foregroundStyle(Color.gray100),
+                    alignment: .bottom
+                )
+        }
+    }
+}
+
+struct RowTitle: View {
+    let title: String
+    var required: Bool = false
+
+    var body: some View {
+        HStack(spacing: 2) {
+            TypographyText(text: title, style: .b2_500)
+            if required {
+                TypographyText(text: "*", style: .b2_500, color: .red)
+            }
+        }
+    }
+}

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/PacePickerRow.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/PacePickerRow.swift
@@ -1,0 +1,103 @@
+//
+//  PacePickerRow.swift
+//  DoRunDoRun
+//
+//  Created by Jaehui Yu on 2/19/26.
+//
+
+import SwiftUI
+
+struct PacePickerRow: View {
+    let title: String
+    var placeholder: String
+    @Binding var minute: Int?
+    @Binding var second: Int?
+
+    @State private var selectedMinute: Int = 5
+    @State private var selectedSecond: Int = 0
+    @State private var isPresented = false
+
+    private var displayText: String {
+        guard let minute, let second else { return "" }
+        return "\(minute)'\(String(format: "%02d", second))\""
+    }
+
+    var body: some View {
+
+        InputRow(title: title) {
+            Button {
+                isPresented = true
+            } label: {
+                HStack {
+                    if minute != nil && second != nil {
+                        TypographyText(
+                            text: displayText,
+                            style: .b1_500,
+                            color: .gray900
+                        )
+                    } else {
+                        TypographyText(
+                            text: placeholder,
+                            style: .b1_500,
+                            color: .gray300
+                        )
+                    }
+
+                    Spacer()
+                }
+            }
+        }
+        .sheet(isPresented: $isPresented) {
+            NavigationStack {
+                VStack {
+
+                    HStack(spacing: 0) {
+
+                        // 분
+                        Picker("Minute", selection: $selectedMinute) {
+                            ForEach(0...59, id: \.self) {
+                                Text("\($0)분").tag($0)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+
+                        // 초
+                        Picker("Second", selection: $selectedSecond) {
+                            ForEach(0...59, id: \.self) {
+                                Text("\($0)초").tag($0)
+                            }
+                        }
+                        .pickerStyle(.wheel)
+                    }
+                    .frame(height: 200)
+
+                }
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("취소") {
+                            isPresented = false
+                        }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("완료") {
+                            minute = selectedMinute
+                            second = selectedSecond
+                            isPresented = false
+                        }
+                    }
+                }
+            }
+            .presentationDetents([.height(300)])
+            .presentationDragIndicator(.visible)
+        }
+        .onAppear {
+            if let minute {
+                selectedMinute = minute
+            }
+            if let second {
+                selectedSecond = second
+            }
+        }
+    }
+}

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/StartTimePickerRow.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/StartTimePickerRow.swift
@@ -1,0 +1,97 @@
+//
+//  StartTimePickerRow.swift
+//  DoRunDoRun
+//
+//  Created by Jaehui Yu on 2/10/26.
+//
+
+import SwiftUI
+
+struct StartTimePickerRow: View {
+    let title: String
+    var required: Bool = false
+    var placeholder: String
+    @Binding var selectedDate: Date?
+
+    @State private var pickerDate: Date = Date()
+    @State private var isPresented: Bool = false
+
+    // MARK: - Display Text
+
+    private var displayText: String {
+        guard let date = selectedDate else { return "" }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "a hh:mm"
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        InputRow(title: title, required: required) {
+            Button {
+                isPresented = true
+            } label: {
+                HStack {
+                    if selectedDate != nil {
+                        TypographyText(
+                            text: displayText,
+                            style: .b1_500,
+                            color: .gray900
+                        )
+                    } else {
+                        TypographyText(
+                            text: placeholder,
+                            style: .b1_500,
+                            color: .gray300
+                        )
+                    }
+
+                    Spacer()
+
+                    Image(.arrowDown, size: .small)
+                }
+            }
+        }
+        .onAppear {
+            if let selectedDate {
+                pickerDate = selectedDate
+            }
+        }
+        .sheet(isPresented: $isPresented) {
+            NavigationStack {
+                VStack {
+                    DatePicker(
+                        "",
+                        selection: $pickerDate,
+                        displayedComponents: .hourAndMinute
+                    )
+                    .datePickerStyle(.wheel)
+                    .labelsHidden()
+                    .environment(\.locale, Locale(identifier: "ko_KR"))
+                    .padding(.top, 20)
+                }
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    // 취소 버튼
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("취소") {
+                            isPresented = false
+                        }
+                    }
+                    // 완료 버튼
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("완료") {
+                            selectedDate = pickerDate
+                            isPresented = false
+                        }
+                    }
+                }
+            }
+            .presentationDetents([.height(300)])
+            .presentationDragIndicator(.visible)
+        }
+    }
+}

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/TextInputRow.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/TextInputRow.swift
@@ -1,0 +1,39 @@
+//
+//  TextInputRow.swift
+//  DoRunDoRun
+//
+//  Created by Jaehui Yu on 2/10/26.
+//
+
+import SwiftUI
+
+struct TextInputRow: View {
+    let title: String
+    var required: Bool = false
+    var placeholder: String
+    var unit: String? = nil
+    var keyboardType: UIKeyboardType = .decimalPad
+
+    @Binding var text: String
+
+    var body: some View {
+        InputRow(title: title, required: required) {
+            HStack {
+                CustomUITextField(
+                    text: $text,
+                    style: .b1_500,
+                    textColor: UIColor(Color.gray900),
+                    placeholder: placeholder,
+                    placeholderColor: UIColor(Color.gray300),
+                    keyboardType: keyboardType,
+                    alignment: .left
+                )
+
+                if let unit {
+                    TypographyText(text: unit, style: .b1_500)
+                }
+            }
+        }
+    }
+}
+

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/SelectSession/Features/SelectSessionFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/SelectSession/Features/SelectSessionFeature.swift
@@ -87,7 +87,8 @@ struct SelectSessionFeature {
                         )
                         
                         // 전체 컨텍스트 기반으로 ViewState 생성
-                        let mapped = RunningSessionSummaryViewStateMapper.map(from: entities)
+                        let mapper = RunningSessionSummaryViewStateMapper()
+                        let mapped = mapper.map(from: entities)
                         
                         // 인증 가능한 세션만 필터링
                         let available = mapped.filter { $0.tagStatus == .possible }

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/SelectSession/Views/SelectSessionView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/SelectSession/Views/SelectSessionView.swift
@@ -20,6 +20,7 @@ struct SelectSessionView: View {
             }
             .onAppear { store.send(.onAppear) }
             .navigationBarBackButtonHidden()
+            .toolbar(.hidden, for: .tabBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
@@ -30,6 +31,16 @@ struct SelectSessionView: View {
                             .foregroundColor(.gray800)
                     }
                 }
+            }
+            .safeAreaInset(edge: .bottom) {
+                AppButton(
+                    title: "불러오기",
+                    style: store.selectedSessionID != nil ? .primary : .disabled,
+                    size: .fullWidth
+                ) {
+                    store.send(.loadButtonTapped)
+                }
+                .padding(.horizontal, 20)
             }
             .navigationDestination(
                 item: $store.scope(state: \.createFeed, action: \.createFeed)
@@ -69,7 +80,6 @@ private extension SelectSessionView {
                     todaySessionListSection
                 }
                 Spacer()
-                buttonSection
             }
             .padding(.horizontal, 20)
         }
@@ -129,17 +139,6 @@ private extension SelectSessionView {
                 }
             }
         }
-    }
-    
-    var buttonSection: some View {
-        AppButton(
-            title: "불러오기",
-            style: store.selectedSessionID != nil ? .primary : .disabled,
-            size: .fullWidth
-        ) {
-            store.send(.loadButtonTapped)
-        }
-        .padding(.bottom, 24)
     }
 }
 

--- a/DoRunDoRun/Sources/Presentation/My/MyProfile/Features/MyProfileFeature.swift
+++ b/DoRunDoRun/Sources/Presentation/My/MyProfile/Features/MyProfileFeature.swift
@@ -255,7 +255,8 @@ struct MyProfileFeature {
                 }
 
             case let .fetchSessionsSuccess(sessions):
-                state.sessions = RunningSessionSummaryViewStateMapper.map(
+                let mapper = RunningSessionSummaryViewStateMapper()
+                state.sessions = mapper.map(
                     from: sessions,
                     currentDate: Date() 
                 )

--- a/DoRunDoRun/Sources/Presentation/My/MyProfile/Mappers/RunningSessionSummaryViewStateMapper.swift
+++ b/DoRunDoRun/Sources/Presentation/My/MyProfile/Mappers/RunningSessionSummaryViewStateMapper.swift
@@ -10,7 +10,7 @@ import Foundation
 import Dependencies
 
 struct RunningSessionSummaryViewStateMapper {
-    static func map(
+    func map(
         from entities: [RunningSessionSummary],
         currentDate: Date = Date()
     ) -> [RunningSessionSummaryViewState] {

--- a/DoRunDoRun/Sources/Presentation/Shared/Views/ActionPopupView.swift
+++ b/DoRunDoRun/Sources/Presentation/Shared/Views/ActionPopupView.swift
@@ -14,6 +14,7 @@ struct ActionPopupView: View {
         case destructive       // 위험 액션 + 취소(닫기) 액션
     }
 
+    let image: Image?
     let title: String
     let message: String?
     let actionTitle: String
@@ -21,8 +22,9 @@ struct ActionPopupView: View {
     let style: PopupStyle
     let onAction: () -> Void
     let onCancel: (() -> Void)?
-    
+
     init(
+         image: Image? = nil,
          title: String,
          message: String?,
          actionTitle: String,
@@ -31,6 +33,7 @@ struct ActionPopupView: View {
          onAction: @escaping () -> Void,
          onCancel: (() -> Void)?
     ) {
+        self.image = image
         self.title = title
         self.message = message
         self.actionTitle = actionTitle
@@ -39,9 +42,15 @@ struct ActionPopupView: View {
         self.onAction = onAction
         self.onCancel = onCancel
     }
-    
+
     var body: some View {
         VStack(spacing: 0) {
+            if let image {
+                image
+                    .resizable()
+                    .frame(width: 120, height: 120)
+                    .padding(.bottom, 12)
+            }
             VStack(spacing: 4) {
                 TypographyText(text: title, style: .t2_700)
 

--- a/DoRunDoRun/Sources/Presentation/_Dependencies/RunningDependency.swift
+++ b/DoRunDoRun/Sources/Presentation/_Dependencies/RunningDependency.swift
@@ -31,6 +31,12 @@ extension DependencyValues {
         get { self[RunningSessionCompleterKey.self] }
         set { self[RunningSessionCompleterKey.self] = newValue }
     }
+
+    // MARK: - 수기 세션 생성
+    var manualSessionCreator: ManualSessionCreatorProtocol {
+        get { self[ManualSessionCreatorKey.self] }
+        set { self[ManualSessionCreatorKey.self] = newValue }
+    }
 }
 
 // MARK: - Keys
@@ -82,4 +88,13 @@ private enum RunningSessionCompleterKey: DependencyKey {
     static let previewValue: RunningSessionCompleterProtocol = RunningSessionCompleter(
         sessionRepository: RunningSessionRepositoryMock()
     )
+}
+
+/// 수기 세션 생성
+private enum ManualSessionCreatorKey: DependencyKey {
+    static let liveValue: ManualSessionCreatorProtocol =
+        ManualSessionCreator(sessionRepository: RunningSessionRepositoryImpl())
+
+    static let testValue: ManualSessionCreatorProtocol =
+        ManualSessionCreator(sessionRepository: RunningSessionRepositoryMock())
 }


### PR DESCRIPTION
## 📌 Overview

피드 업로드 플로우를 전반적으로 개선하고, 수기 러닝 기록 기능을 추가했습니다.
플로팅 버튼 구조를 변경하여 세션 선택과 직접 기록 흐름을 명확히 분리했으며, 인증 완료된 세션에 대해 중복 업로드가 발생하지 않도록 UX를 보완했습니다.

---

## ✨ 주요 변경 사항

### 1. 수기 러닝 기록 기능 추가

* `EnterManualSessionFeature` 구현
* 플로팅 버튼 → 수기 기록 화면 네비게이션 연결
* 러닝 세션 기록 관련 서버 연동 처리

### 2. 피드 업로드 진입 구조 개선

* 플로팅 버튼을 세션 선택 / 직접 기록 분기 구조로 변경
* delegate 기반 네비게이션 흐름 정리

### 3. 인증 완료 상태 예외 처리

* 인증 완료된 상태에서 업로드 버튼 클릭 시

  * 업로드 화면 진입 차단
  * "이미 인증 완료" 안내 팝업 노출
* 중복 인증 방지 로직 추가

### 4. 기타 수정 사항

* 세션 선택/수기 기록 화면에서 탭바 제거
* 일부 네비게이션 및 상태 관리 구조 정리

---

## 🧪 테스트 체크리스트

* [ ] 세션 선택 → 업로드 정상 진입 확인
* [ ] 수기 기록 → 서버 저장 정상 동작 확인
* [ ] 인증 완료 상태 → 업로드 버튼 클릭 시 팝업 노출 확인
* [ ] 인증 미완료 상태 → 정상 업로드 진입 확인
* [ ] 네비게이션 스택 이상 여부 확인

---

## 🎯 기대 효과

* 업로드 퍼널 흐름 명확화
* 중복 인증 방지로 UX 안정성 향상
* 수기 기록 기능 추가로 사용성 확장
