### PR TITLE
[Feat] Running 화면 phase 기반 UI 개선 및 카운트다운 건너뛰기 기능 추가

### DIFF
--- a/DoRunDoRun/Sources/DesignSystem/Components/AppButton.swift
+++ b/DoRunDoRun/Sources/DesignSystem/Components/AppButton.swift
@@ -3,6 +3,7 @@ import SwiftUI
 // MARK: - 버튼 스타일
 enum AppButtonStyle {
     case primary
+    case primaryInverse
     case secondary
     case destructive
     case disabled
@@ -141,6 +142,8 @@ struct AppButton: View {
         switch style {
         case .primary:
             return .blue600
+        case .primaryInverse:
+            return .gray0
         case .secondary:
             switch size {
             case .fullWidth:
@@ -163,6 +166,8 @@ struct AppButton: View {
         switch style {
         case .primary:
             return .gray0
+        case .primaryInverse:
+            return .blue600
         case .secondary:
             switch size {
             case .fullWidth:

--- a/DoRunDoRun/Sources/DesignSystem/Typography/TypogrphyStyle.swift
+++ b/DoRunDoRun/Sources/DesignSystem/Typography/TypogrphyStyle.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum TypographyStyle: CaseIterable {
     case countdown_700
+    case distance_700
     
     // MARK: - Headline
     case h1_700, h1_500
@@ -23,6 +24,8 @@ enum TypographyStyle: CaseIterable {
         switch self {
         case .countdown_700:
             return .init(size: 96, lineHeight: 106, letterSpacing: -0.2, weight: .bold, textStyle: .largeTitle)
+        case .distance_700:
+            return .init(size: 68, lineHeight: 50, letterSpacing: -0.2, weight: .bold, textStyle: .largeTitle)
         // MARK: - Headline
         case .h1_700:
             return .init(size: 28, lineHeight: 38, letterSpacing: -0.2, weight: .bold, textStyle: .largeTitle)

--- a/DoRunDoRun/Sources/Presentation/Running/RunningCountdown/Views/RunningCountdownView.swift
+++ b/DoRunDoRun/Sources/Presentation/Running/RunningCountdown/Views/RunningCountdownView.swift
@@ -31,9 +31,9 @@ struct RunningCountdownView: View {
 }
 
 private extension RunningCountdownView {
-    /// 반투명 배경
+    /// 투명 배경 (RunningView에서 파란 배경 제공)
     var backgroundLayer: some View {
-        Color.black.opacity(0.73)
+        Color.clear
             .ignoresSafeArea()
     }
 
@@ -51,8 +51,6 @@ private extension RunningCountdownView {
     /// 숫자 카운트다운 표시
     func countdownContent(_ count: Int) -> some View {
         VStack(spacing: 32) {
-            TypographyText(text: "잠시 후 러닝 시작", style: .h4_700, color: .gray0)
-
             ZStack {
                 Circle()
                     .stroke(Color(hex: 0xD9D9D9).opacity(0.25), style: StrokeStyle(lineWidth: 10, lineCap: .square))

--- a/DoRunDoRun/Sources/Presentation/Running/RunningCountdown/Views/RunningCountdownView.swift
+++ b/DoRunDoRun/Sources/Presentation/Running/RunningCountdown/Views/RunningCountdownView.swift
@@ -64,6 +64,13 @@ private extension RunningCountdownView {
             }
             .onAppear(perform: restartAnimation)
             .onChange(of: count) { _ in restartAnimation() }
+            
+            Button {
+                store.send(.skipCountdown)
+            } label: {
+                TypographyText(text: "카운트다운 건너뛰기", style: .t1_700, color: .gray0)
+            }
+
         }
         .padding(.horizontal, 30)
     }


### PR DESCRIPTION
## 📌 Overview

Running 화면을 phase 기반 구조로 정리하고, 카운트다운 UX를 개선했습니다.
기존에 항상 지도 기반으로 렌더링되던 구조를 `.ready / .countdown / .active` 단계별로 분리하여 각 상태에 맞는 화면만 렌더링하도록 수정했습니다.
또한 러닝 카운트다운 단계에서 사용자가 즉시 시작할 수 있도록 “건너뛰기” 기능을 추가했습니다.

---

## ✨ 주요 변경 사항

### 1️⃣ RunningView 구조 개선

* 항상 `RunningMapView`를 렌더링하던 구조 제거
* phase 기반 UI 분리

#### 🔹 .ready

* 기존과 동일하게 지도 + 준비 화면 구성

#### 🔹 .countdown

* `Color.blue600` 파란 배경 적용
* 카운트다운 전용 화면 표시

#### 🔹 .active

* `Color.blue600` 파란 배경/`Color.gray0` 흰 배경 적용
* 기록 시트 중심 UI 구성
* 지도 미노출

---

### 2️⃣ RunningCountdownView 수정

* `backgroundLayer` 제거

  * `Color.black.opacity(0.73)` → `Color.clear`
* 상위 `RunningView`에서 배경을 관리하도록 구조 변경

→ 뷰 책임 분리 및 배경 중복 제거

---

### 3️⃣ RunningActiveView 정리

* GPS 버튼 및 `gpsButton` 함수 제거
* 지도 미노출 구조로 변경됨에 따라 지도 따라가기 버튼 제거

→ UI 단순화

---

### 4️⃣ 카운트다운 건너뛰기 기능 추가

* 카운트다운 진행 중 “건너뛰기” 버튼 추가
* 즉시 `.active` 단계로 전환 가능
* 사용자 제어권 강화 및 UX 개선

---

## 🧪 테스트 체크리스트

* [ ] ready → countdown → active 정상 전환 확인
* [ ] countdown 배경이 정상 적용되는지 확인
* [ ] active 단계에서 GPS 버튼이 노출되지 않는지 확인
* [ ] 카운트다운 중 건너뛰기 클릭 시 즉시 active 진입 확인
* [ ] 러닝 기록 정상 시작 여부 확인
