### PR TITLE
[Refactor] manual session 응답에 createdAt 필드 반영

### DIFF
--- a/DoRunDoRun/Sources/Data/DTO/Running/ManualSessionResponseDTO.swift
+++ b/DoRunDoRun/Sources/Data/DTO/Running/ManualSessionResponseDTO.swift
@@ -16,6 +16,7 @@ struct ManualSessionResponseDTO: Decodable {
 
 struct ManualSessionDataDTO: Decodable, Equatable {
     let id: Int
+    let createdAt: String
     let finishedAt: String
     let durationTotal: Int
     let distanceTotal: Int
@@ -30,7 +31,7 @@ extension ManualSessionDataDTO {
         
         return RunningSessionSummary(
             sessionId: id,
-            createdAt: parser.isoDate(from: finishedAt) ?? Date(),
+            createdAt: parser.isoDate(from: createdAt) ?? Date(),
             finishedAt: parser.isoDate(from: finishedAt) ?? Date(),
             totalDistanceMeters: Double(distanceTotal),
             totalDurationSeconds: durationTotal,


### PR DESCRIPTION
## 📌 Overview

수기 러닝 기록(manual session) 서버 응답에 `createdAt` 필드가 추가됨에 따라,
DTO 및 Entity 매핑 로직에 해당 필드를 반영했습니다.

기존에는 `finishedAt`만 응답으로 내려왔으나,
생성 시점을 명확히 구분하기 위해 `createdAt`을 함께 수신하도록 구조를 수정했습니다.

---

## ✨ 주요 변경 사항

### 1️⃣ Manual Session Response DTO 수정

* 서버 응답에 추가된 `createdAt` 필드 반영
* 관련 타입 정의 업데이트

```swift
createdAt: String
```

---

### 2️⃣ DTO → Entity 매핑 로직 수정

* 기존 `finishedAt` 중심 매핑 구조에
* `createdAt` 매핑 추가
* Entity에 생성 시점 정보가 정상 반영되도록 수정

---

### 3️⃣ 기존 로직 영향 범위

* 수기 러닝 기록 생성/조회 흐름 정상 동작 유지
* 기존 `finishedAt` 기반 로직에는 영향 없음
* 단순 필드 확장 대응

---

## 🧪 테스트 체크리스트

* [ ] 수기 기록 생성 시 서버 응답에 `createdAt` 정상 수신 확인
* [ ] DTO → Entity 매핑에 `createdAt` 값 반영 확인
* [ ] 기존 `finishedAt` 기반 기능 정상 동작 확인
* [ ] 크래시 및 디코딩 오류 없음 확인

---

## 🎯 기대 효과

* 서버 스펙과 클라이언트 모델 일치
* 생성 시점과 종료 시점 명확 분리
* 향후 정렬/표시 로직 확장 기반 마련
