### PR TITLE
[Refactor] 토큰 리프레시 결과 분리 및 세션 만료 처리 로직 개선

### DIFF
--- a/DoRunDoRun/Sources/App/AppFeature.swift
+++ b/DoRunDoRun/Sources/App/AppFeature.swift
@@ -45,7 +45,7 @@ struct AppFeature {
 
         case splash(SplashFeature.Action)
         case appStarted
-        case refreshTokenResponse(Bool) // refresh 결과 처리
+        case refreshTokenResponse(RefreshResult) // refresh 결과 처리
 
         // 로그인 전
         case onboarding(OnboardingFeature.Action)
@@ -122,14 +122,18 @@ struct AppFeature {
                     }
                 }
 
-            case let .refreshTokenResponse(success):
-                if success {
-                    print("자동 로그인 성공 (토큰 갱신 완료)")
+            case let .refreshTokenResponse(result):
+                switch result {
+                case .success:
+                    print("✅ 자동 로그인 성공 (토큰 갱신 완료)")
                     state.isLoggedIn = true
-                } else {
-                    print("자동 로그인 실패 → 온보딩 전환")
+                case .serverRejected:
+                    print("❌ 자동 로그인 실패 (서버 거부) → 온보딩 전환")
                     TokenManager.shared.clear()
                     state.isLoggedIn = false
+                case .networkError:
+                    print("⚠️ 자동 로그인 - 네트워크 오류, 토큰 유지 후 로그인 유지")
+                    state.isLoggedIn = true
                 }
                 return .none
                 


### PR DESCRIPTION
## 📌 Overview

토큰 리프레시 실패 케이스를 세분화하고,
네트워크 오류와 서버 거절을 구분하여 세션 처리 로직을 개선했습니다.

기존에는 `tryRefresh()`가 `Bool`을 반환하여 실패 원인을 구분할 수 없었으나,
이번 변경을 통해 실패 유형에 따라 다른 인증 흐름을 적용하도록 구조를 개선했습니다.

---

## ✨ 주요 변경 사항

### 1️⃣ TokenRefresher 개선

* `RefreshResult` enum 추가

  ```swift
  enum RefreshResult {
      case success
      case networkError
      case serverRejected
  }
  ```

* `tryRefresh()` 반환 타입 변경

  ```
  Bool → RefreshResult
  ```

* catch 블록에서 에러 타입 구분

  * `URLError` → `.networkError`
  * `MoyaError` → `.serverRejected`

* refresh token이 없는 경우 → `.serverRejected`
  (서버에 보내도 거절될 상황이므로 명확히 구분)

---

### 2️⃣ AppFeature 세션 처리 로직 수정

* `.networkError`

  * 토큰 유지
  * 로그인 상태 유지
  * 이후 API 호출 시 `TokenInterceptor`에서 재시도 처리

* `.serverRejected`

  * 기존과 동일하게 토큰 삭제
  * 온보딩 화면으로 이동

→ 네트워크 단절과 실제 인증 실패를 명확히 분리

---

### 3️⃣ TokenInterceptor 수정

* `.networkError` 발생 시

  * `.sessionExpired` 알림 제거
  * `doNotRetry` 처리만 수행

→ 네트워크 문제로 인한 불필요한 세션 만료 UX 방지

---

## 🧪 테스트 체크리스트

* [ ] refresh token 정상 갱신 시 `.success` 처리 확인
* [ ] 네트워크 단절 시 세션 유지 확인
* [ ] 서버에서 refresh 거절 시 토큰 삭제 및 온보딩 이동 확인
* [ ] 네트워크 오류 시 `.sessionExpired` 알림이 발생하지 않는지 확인
* [ ] 기존 API retry 흐름 정상 동작 확인

---

## 🎯 기대 효과

* 네트워크 오류와 인증 실패 구분
* 불필요한 로그아웃 방지
* 세션 안정성 향상
* 인증 플로우 가독성 및 유지보수성 개선
