### PR TITLE
[Fix] 수기 입력 및 세션/피드 UI 관련 버그 수정 및 레이아웃 개선

### DIFF
--- a/DoRunDoRun/Sources/Data/DTO/Running/ManualSessionResponseDTO.swift
+++ b/DoRunDoRun/Sources/Data/DTO/Running/ManualSessionResponseDTO.swift
@@ -16,11 +16,11 @@ struct ManualSessionResponseDTO: Decodable {
 
 struct ManualSessionDataDTO: Decodable, Equatable {
     let id: Int
-    let createdAt: String
+    let startedAt: String
     let finishedAt: String
     let durationTotal: Int
     let distanceTotal: Int
-    let paceAvg: Int
+    let paceAvg: Double
     let cadenceAvg: Int
 }
 
@@ -28,14 +28,14 @@ struct ManualSessionDataDTO: Decodable, Equatable {
 extension ManualSessionDataDTO {
     func toDomain() -> RunningSessionSummary {
         let parser = DateFormatterManager.shared
-        
+
         return RunningSessionSummary(
             sessionId: id,
-            createdAt: parser.isoDate(from: createdAt) ?? Date(),
+            createdAt: parser.isoDate(from: startedAt) ?? Date(),
             finishedAt: parser.isoDate(from: finishedAt) ?? Date(),
             totalDistanceMeters: Double(distanceTotal),
             totalDurationSeconds: durationTotal,
-            avgPaceSecPerKm: Double(paceAvg),
+            avgPaceSecPerKm: paceAvg,
             avgCadenceSpm: Double(cadenceAvg),
             isSelfied: false,
             mapImageURL: nil

--- a/DoRunDoRun/Sources/Data/DTO/Running/RunningSessionDetailResponseDTO.swift
+++ b/DoRunDoRun/Sources/Data/DTO/Running/RunningSessionDetailResponseDTO.swift
@@ -23,11 +23,11 @@ struct RunningSessionDetailDataDTO: Decodable {
     let distanceTotal: Int
     let durationTotal: Int
     let paceAvg: Int
-    let paceMax: Int
-    let paceMaxLatitude: Double
-    let paceMaxLongitude: Double
+    let paceMax: Int?
+    let paceMaxLatitude: Double?
+    let paceMaxLongitude: Double?
     let cadenceAvg: Int
-    let cadenceMax: Int
+    let cadenceMax: Int?
     let mapImage: String?
     let feed: FeedDTO?
     let segments: [[SegmentPointDTO]]
@@ -74,8 +74,8 @@ extension RunningSessionDetailDataDTO {
         let maxPacePoint = RunningPoint(
             timestamp: Date(),
             coordinate: RunningCoordinate(
-                latitude: paceMaxLatitude,
-                longitude: paceMaxLongitude
+                latitude: paceMaxLatitude ?? 0,
+                longitude: paceMaxLongitude ?? 0
             ),
             altitude: 0.0,
             speedMps: 0.0
@@ -100,8 +100,8 @@ extension RunningSessionDetailDataDTO {
             elapsed: .seconds(durationTotal),
             avgPaceSecPerKm: Double(paceAvg),
             avgCadenceSpm: Double(cadenceAvg),
-            maxCadenceSpm: Double(cadenceMax),
-            fastestPaceSecPerKm: Double(paceMax),
+            maxCadenceSpm: Double(cadenceMax ?? 0),
+            fastestPaceSecPerKm: Double(paceMax ?? 0),
             coordinateAtmaxPace: maxPacePoint,
             coordinates: allCoordinates,
             mapImageData: nil,

--- a/DoRunDoRun/Sources/Presentation/Feed/Feed/Views/FeedView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/Feed/Views/FeedView.swift
@@ -251,7 +251,7 @@ private extension FeedView {
             HStack(spacing: 0) {
                 TypographyText(text: title, style: .b1_500, color: .gray700)
             }
-            .frame(width: 152)
+            .frame(width: 152, alignment: .leading)
             .padding(.vertical, 4)
             .padding(.horizontal, 16)
         }

--- a/DoRunDoRun/Sources/Presentation/Feed/Feed/Views/FeedView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/Feed/Views/FeedView.swift
@@ -251,6 +251,7 @@ private extension FeedView {
             HStack(spacing: 0) {
                 TypographyText(text: title, style: .b1_500, color: .gray700)
             }
+            .frame(width: 152)
             .padding(.vertical, 4)
             .padding(.horizontal, 16)
         }

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/CreateFeed/Views/CreateFeedView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/CreateFeed/Views/CreateFeedView.swift
@@ -114,7 +114,6 @@ private extension CreateFeedView {
 
             // 기본 템플릿 이미지
             } else if let template = store.randomTemplate {
-
                 Image(template.rawValue)
                     .resizable()
                     .scaledToFill()
@@ -132,7 +131,7 @@ private extension CreateFeedView {
                     .cornerRadius(16)
                     .overlay {
                         VStack(spacing: 8) {
-                            Image(.camera)
+                            Image(.camera, fill: .fill, size: .medium)
                                 .renderingMode(.template)
                                 .foregroundColor(.gray400)
                             TypographyText(text: "배경사진을 추가해보세요", style: .b2_400, color: .gray500)
@@ -143,7 +142,7 @@ private extension CreateFeedView {
             // 달리기 정보 오버레이
             runningInfoOverlay
         }
-        .padding(.top, 40)
+        .padding(.top, 32)
     }
 
     /// 달리기 정보 오버레이

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/EnterManualSessionView.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/EnterManualSessionView.swift
@@ -123,6 +123,8 @@ private extension EnterManualSessionView {
                                 title: "케이던스",
                                 placeholder: "케이던스 입력(선택)",
                                 unit: store.cadence.isEmpty ? nil : "spm",
+                                keyboardType: .numberPad,
+                                maxLength: 3,
                                 text: $store.cadence
                             )
                         }

--- a/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/TextInputRow.swift
+++ b/DoRunDoRun/Sources/Presentation/Feed/UploadFeed/EnterManualSession/Views/TextInputRow.swift
@@ -13,6 +13,7 @@ struct TextInputRow: View {
     var placeholder: String
     var unit: String? = nil
     var keyboardType: UIKeyboardType = .decimalPad
+    var maxLength: Int? = nil
 
     @Binding var text: String
 
@@ -26,7 +27,8 @@ struct TextInputRow: View {
                     placeholder: placeholder,
                     placeholderColor: UIColor(Color.gray300),
                     keyboardType: keyboardType,
-                    alignment: .left
+                    alignment: .left,
+                    maxLength: maxLength
                 )
 
                 if let unit {

--- a/DoRunDoRun/Sources/Presentation/Running/SessionDetail/Views/SessionDetailView.swift
+++ b/DoRunDoRun/Sources/Presentation/Running/SessionDetail/Views/SessionDetailView.swift
@@ -69,8 +69,10 @@ private extension SessionDetailView {
                     VStack(alignment: .leading, spacing: 0) {
                         headerSection(detail)
                         summarySection(detail)
-                        mapSection(detail)
-                        paceColorBar
+                        if !detail.points.isEmpty {
+                            mapSection(detail)
+                            paceColorBar
+                        }
 
                         // MARK: CTA 조건
                         if detail.feed != nil {


### PR DESCRIPTION
## 📌 개요

수기 입력 관련 오류 수정과 함께 세션 상세 및 피드 화면의 UI/레이아웃을 개선했습니다.

---

## 🔧 변경 사항

### 1. 수기 입력 (Manual Session)

* 케이던스 포매팅 적용
* 케이던스 입력값 3자리 제한
* DTO 필드명 및 타입 수정

  * `ManualSessionResponseDTO`
  * `RunningSessionDetailResponseDTO`

---

### 2. SessionDetailView

* `points` 유무에 따른 UI 분기 처리

  * `points.isEmpty` (수기 세션)
    → 지도 및 페이스 컬러 바 숨김
  * GPS 세션
    → 기존 UI 유지

---

### 3. Feed (플로팅 버튼)

* 플로팅 메뉴 버튼 width 조정
* 플로팅 메뉴 버튼 좌측 정렬 적용

---

### 4. CreateFeedView

* 아이콘 및 패딩 값 조정
* UI 디테일 개선

---

## 🎯 변경 목적

* 수기 입력 데이터 처리의 정확성 개선
* 잘못된 DTO 정의로 인한 데이터 불일치 해결
* UI 일관성 및 사용성 개선
* 수기 세션과 GPS 세션 간 UI 표현 명확화

---

## 🧪 테스트 방법

* [ ] 수기 입력 시 케이던스 입력 (3자리 제한 확인)
* [ ] 수기 세션 상세 진입 시 지도/페이스 바 미노출 확인
* [ ] GPS 세션 상세 진입 시 정상 노출 확인
* [ ] 피드 플로팅 버튼 UI 정렬 및 영역 확인
* [ ] CreateFeedView UI 레이아웃 확인

---

## 📸 참고 (선택)

필요 시 스크린샷 추가
