### PR TITLE
[Fix] ATT 권한 요청 추가 및 빌드 버전 업데이트

### DIFF
--- a/DoRunDoRun/Project.swift
+++ b/DoRunDoRun/Project.swift
@@ -82,7 +82,7 @@ let project = Project(
                 base: [
                     "OTHER_LDFLAGS": "-ObjC",
                     "MARKETING_VERSION": "1.1.0",
-                    "CURRENT_PROJECT_VERSION": "2"
+                    "CURRENT_PROJECT_VERSION": "3"
                 ],
                 configurations: [
                     .debug(name: "Debug", xcconfig: "../Configs/Debug.xcconfig"),

--- a/DoRunDoRun/Sources/App/AppDelegate.swift
+++ b/DoRunDoRun/Sources/App/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AppTrackingTransparency
 import FirebaseCore
 import FirebaseMessaging
 import UserNotifications
@@ -18,11 +19,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     ) -> Bool {
         // Firebase 설정
         FirebaseApp.configure()
-        
-        // AdMob 초기화
-        MobileAds.shared.start(completionHandler: nil)
-        InterstitialAdManager.shared.loadAd()
-        
+
+        // ATT 권한 요청 후 AdMob 초기화 (Apple 가이드라인: 데이터 수집 전 권한 획득)
+        ATTrackingManager.requestTrackingAuthorization { _ in
+            DispatchQueue.main.async {
+                MobileAds.shared.start(completionHandler: nil)
+                InterstitialAdManager.shared.loadAd()
+            }
+        }
+
         // 앱 실행 시 사용자에게 알림 허용 권한을 받음
         UNUserNotificationCenter.current().delegate = self
         


### PR DESCRIPTION
## Summary

- `AppTrackingTransparency` 프레임워크 import 및 `ATTrackingManager.requestTrackingAuthorization` 호출 추가
- AdMob 초기화(`MobileAds.shared.start`, `InterstitialAdManager.shared.loadAd`)를 ATT 응답 콜백 이후로 이동하여 Apple 가이드라인 준수
- 빌드 버전 `2` → `3` 업데이트

## Background

App Store 심사(Submission ID: 28a685f9-2613-4494-b9c9-8805390dd3ed)에서 Guideline 2.1 위반으로 거절됨.
`NSUserTrackingUsageDescription`은 선언되어 있었으나 실제 ATT 권한 요청 다이얼로그 호출 코드가 누락된 상태였음.

## Test plan

- [ ] 실기기에서 앱 새로 설치 후 실행 시 ATT 권한 다이얼로그 표시 확인
- [ ] ATT 허용/거부 각각의 경우 AdMob 광고 정상 동작 확인
- [ ] 설정 > 개인 정보 보호 > 추적에서 권한 초기화 후 재실행 시 다이얼로그 재표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앱 추적 투명성 권한 요청 기능을 추가했습니다.

* **기타**
  * 빌드 버전을 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/17th-team6-iOS/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->