### PR TITLE
[Fix] ATT 권한 요청을 applicationDidBecomeActive로 이동

### DIFF
--- a/DoRunDoRun/Project.swift
+++ b/DoRunDoRun/Project.swift
@@ -82,7 +82,7 @@ let project = Project(
                 base: [
                     "OTHER_LDFLAGS": "-ObjC",
                     "MARKETING_VERSION": "1.1.0",
-                    "CURRENT_PROJECT_VERSION": "3"
+                    "CURRENT_PROJECT_VERSION": "4"
                 ],
                 configurations: [
                     .debug(name: "Debug", xcconfig: "../Configs/Debug.xcconfig"),

--- a/DoRunDoRun/Sources/App/AppDelegate.swift
+++ b/DoRunDoRun/Sources/App/AppDelegate.swift
@@ -20,14 +20,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // Firebase 설정
         FirebaseApp.configure()
 
-        // ATT 권한 요청 후 AdMob 초기화 (Apple 가이드라인: 데이터 수집 전 권한 획득)
-        ATTrackingManager.requestTrackingAuthorization { _ in
-            DispatchQueue.main.async {
-                MobileAds.shared.start(completionHandler: nil)
-                InterstitialAdManager.shared.loadAd()
-            }
-        }
-
         // 앱 실행 시 사용자에게 알림 허용 권한을 받음
         UNUserNotificationCenter.current().delegate = self
         
@@ -44,6 +36,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         Messaging.messaging().delegate = self
         
         return true
+    }
+
+    // 앱이 active 상태가 된 후 ATT 요청 — didFinishLaunching은 아직 inactive 상태라 iOS 26에서 다이얼로그가 표시되지 않음
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        guard ATTrackingManager.trackingAuthorizationStatus == .notDetermined else {
+            MobileAds.shared.start(completionHandler: nil)
+            InterstitialAdManager.shared.loadAd()
+            return
+        }
+        ATTrackingManager.requestTrackingAuthorization { _ in
+            DispatchQueue.main.async {
+                MobileAds.shared.start(completionHandler: nil)
+                InterstitialAdManager.shared.loadAd()
+            }
+        }
     }
 
     // 백그라운드에서 푸시 알림을 탭했을 때 실행


### PR DESCRIPTION
## Summary

- requestTrackingAuthorization을 didFinishLaunchingWithOptions에서 applicationDidBecomeActive로 이동
- iOS 26에서 inactive 상태일 때 ATT 요청이 무시되는 문제 수정
- 빌드 버전 3 → 4

## Background

App Store 재심사(1.1.0(3))에서 동일한 Guideline 2.1로 재거절. didFinishLaunchingWithOptions 시점은 앱이 아직 active 상태가 아니라 iOS 26에서 ATT 다이얼로그가 표시되지 않는 것으로 확인.

## Test plan

- [ ] 실기기에서 앱 새로 설치 후 ATT 다이얼로그 표시 확인
- [ ] ATT 허용/거부 각각의 경우 AdMob 광고 정상 동작 확인
- [ ] 설정 > 개인정보 보호 > 추적에서 초기화 후 재실행 시 다이얼로그 재표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로젝트 버전을 4로 업데이트했습니다.

* **Bug Fixes**
  * 광고 로딩 시점을 앱 시작 시에서 앱이 활성화되는 순간으로 조정했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/17th-team6-iOS/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->