### PR TITLE
[Fix] ATT 권한 요청 asyncAfter 딜레이 적용

### DIFF
--- a/DoRunDoRun/Project.swift
+++ b/DoRunDoRun/Project.swift
@@ -82,7 +82,7 @@ let project = Project(
                 base: [
                     "OTHER_LDFLAGS": "-ObjC",
                     "MARKETING_VERSION": "1.1.0",
-                    "CURRENT_PROJECT_VERSION": "4"
+                    "CURRENT_PROJECT_VERSION": "5"
                 ],
                 configurations: [
                     .debug(name: "Debug", xcconfig: "../Configs/Debug.xcconfig"),

--- a/DoRunDoRun/Sources/App/AppDelegate.swift
+++ b/DoRunDoRun/Sources/App/AppDelegate.swift
@@ -22,35 +22,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         // 앱 실행 시 사용자에게 알림 허용 권한을 받음
         UNUserNotificationCenter.current().delegate = self
-        
-        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound] // 필요한 알림 권한을 설정
-        UNUserNotificationCenter.current().requestAuthorization(
-            options: authOptions,
-            completionHandler: { _, _ in }
-        )
-        
-        // UNUserNotificationCenterDelegate를 구현한 메서드를 실행시킴
         application.registerForRemoteNotifications()
-        
-        // Firebase Meesaging 설정
-        Messaging.messaging().delegate = self
-        
-        return true
-    }
 
-    // 앱이 active 상태가 된 후 ATT 요청 — didFinishLaunching은 아직 inactive 상태라 iOS 26에서 다이얼로그가 표시되지 않음
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        guard ATTrackingManager.trackingAuthorizationStatus == .notDetermined else {
-            MobileAds.shared.start(completionHandler: nil)
-            InterstitialAdManager.shared.loadAd()
-            return
-        }
-        ATTrackingManager.requestTrackingAuthorization { _ in
-            DispatchQueue.main.async {
-                MobileAds.shared.start(completionHandler: nil)
-                InterstitialAdManager.shared.loadAd()
+        // Firebase Messaging 설정
+        Messaging.messaging().delegate = self
+
+        // 앱 실행 직후에는 window가 준비되지 않아 ATT 다이얼로그가 무시됨 — 1초 지연 후 요청
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            ATTrackingManager.requestTrackingAuthorization { _ in
+                DispatchQueue.main.async {
+                    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, _ in }
+                    MobileAds.shared.start(completionHandler: nil)
+                    InterstitialAdManager.shared.loadAd()
+                }
             }
         }
+
+        return true
     }
 
     // 백그라운드에서 푸시 알림을 탭했을 때 실행


### PR DESCRIPTION
## Summary

- didFinishLaunchingWithOptions에서 1초 딜레이 후 ATT 요청 (window 준비 전 무시 문제 해결)
- ATT 응답 후 알림 권한 요청 순서 보장
- 빌드 버전 4 → 5

## Background

App Store 재심사(1.1.0(4))에서 동일한 Guideline 2.1로 재거절. 앱 실행 직후 window가 준비되지 않은 상태에서 ATT 요청이 무시되는 문제 확인. asyncAfter 1초 딜레이로 해결.

## Test plan

- [ ] 실기기 설정 > 개인정보 보호 > 추적 초기화 후 ATT 다이얼로그 표시 확인
- [ ] ATT 응답 후 알림 권한 다이얼로그 표시 확인
- [ ] ATT 허용/거부 각각의 경우 AdMob 광고 정상 동작 확인